### PR TITLE
Enhanced support for emojis

### DIFF
--- a/features/emoji.feature
+++ b/features/emoji.feature
@@ -61,6 +61,22 @@ Feature: Using Emoji in your Slides
     | //link[@rel="stylesheet"][@href="css/reveal-ck.css"]                               | the default reveal-ck.css     |
     And a file named "slides/css/reveal-ck.css" should exist
 
+  Scenario: Including :money_with_wings: a markdown slides file
+    Given a file named "slides.md" with:
+    """
+    # Emoji
+
+    :money_with_wings:
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the file "slides/slides.html" should have html matching the xpath:
+    | //section/p/img[@class="emoji"]                         | an img with class emoji               |
+    | //section/p/img[@title=":money_with_wings:"]            | an img with title=":money_with_wings" |
+    | //section/p/img[@alt=":money_with_wings:"]              | an img with alt=":money_with_wings"   |
+    | //section/p/img[contains(@src, "money_with_wings.png")] | an img with src on github cdn         |
+    And a file named "slides/css/reveal-ck.css" should exist
+
   Scenario: Including Emoji hosted at a specific location
     Given a file named "slides.md" with:
     """

--- a/lib/reveal-ck/markdown.rb
+++ b/lib/reveal-ck/markdown.rb
@@ -2,9 +2,10 @@ module RevealCK
   # This module defines how reveal-ck works with redcarpet to produce
   # slides from markdown.
   module Markdown
-    REVEALCK_SYMBOL_FOR_DIVIDER        = '<div>DIVIDER</div>'
-    REVEALCK_SYMBOL_FOR_VERTICAL_START = '<div>VERTICAL_START</div>'
-    REVEALCK_SYMBOL_FOR_VERTICAL_END   = '<div>VERTICAL_END</div>'
+    REVEALCK_SYMBOL_FOR_DIVIDER          = '<div>DIVIDER</div>'
+    REVEALCK_SYMBOL_FOR_VERTICAL_START   = '<div>VERTICAL_START</div>'
+    REVEALCK_SYMBOL_FOR_VERTICAL_END     = '<div>VERTICAL_END</div>'
+    REVEALCK_SYMBOL_FOR_EMOJI_UNDERSCORE = 'EU'
   end
 end
 

--- a/lib/reveal-ck/markdown/post_processor.rb
+++ b/lib/reveal-ck/markdown/post_processor.rb
@@ -11,6 +11,7 @@ module RevealCK
 
       def process
         strip_whitespace
+        unprotect_emojis
         handle_start
         handle_end
         transform_symbols_to_sections
@@ -20,6 +21,12 @@ module RevealCK
 
       def strip_whitespace
         @doc = doc.strip
+      end
+
+      def unprotect_emojis
+        @doc = doc.gsub(protected_emoji_regex) do |protected_emoji|
+          protected_emoji.gsub(emoji_underscore_symbol, '_')
+        end
       end
 
       def handle_start
@@ -84,6 +91,10 @@ module RevealCK
         "#{divider_end}\n#{divider_start}"
       end
 
+      def emoji_underscore_symbol
+        RevealCK::Markdown::REVEALCK_SYMBOL_FOR_EMOJI_UNDERSCORE
+      end
+
       def divider_symbol
         RevealCK::Markdown::REVEALCK_SYMBOL_FOR_DIVIDER
       end
@@ -94,6 +105,10 @@ module RevealCK
 
       def vertical_end_symbol
         RevealCK::Markdown::REVEALCK_SYMBOL_FOR_VERTICAL_END
+      end
+
+      def protected_emoji_regex
+        /:[a-z\d_\-\+EU]*:/
       end
 
       def back_to_back_vertical_symbols_regex

--- a/lib/reveal-ck/markdown/pre_processor.rb
+++ b/lib/reveal-ck/markdown/pre_processor.rb
@@ -11,6 +11,7 @@ module RevealCK
 
       def process
         strip_whitespace
+        protect_emojis
         add_first_slide_divider_if_needed
         add_last_slide_vertical_if_needed
         add_last_slide_divider_if_needed
@@ -23,6 +24,12 @@ module RevealCK
 
       def strip_whitespace
         @doc = doc.strip
+      end
+
+      def protect_emojis
+        @doc = doc.gsub(emoji_regex) do |emoji|
+          emoji.gsub(/_/, emoji_underscore_symbol)
+        end
       end
 
       def add_first_slide_divider_if_needed
@@ -60,6 +67,10 @@ module RevealCK
         append(slide_vertical)
       end
 
+      def emoji_regex
+        /:[a-z\d_\-\+]*:/
+      end
+
       def slide_divider
         '---'
       end
@@ -86,6 +97,10 @@ module RevealCK
 
       def newline_wrapped(s)
         "\n#{s}\n"
+      end
+
+      def emoji_underscore_symbol
+        RevealCK::Markdown::REVEALCK_SYMBOL_FOR_EMOJI_UNDERSCORE
       end
 
       def divider_symbol

--- a/spec/lib/reveal-ck/commands/serve_spec.rb
+++ b/spec/lib/reveal-ck/commands/serve_spec.rb
@@ -116,7 +116,7 @@ module RevealCK
               # Creating the file will trigger the call back. But need
               # to wait else the expecation of :rebuild_slides will
               # fail-- it's not instantaneous
-              sleep 0.25
+              sleep 0.5
             end
           end
         end

--- a/spec/lib/reveal-ck/markdown/post_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/post_processor_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper'
 module RevealCK
   module Markdown
     describe PostProcessor do
+      it 'unprotects emojis' do
+        input = ':moneyEUwithEUwings:'
+        output = PostProcessor.new(input).process
+        expect(output).to include ':money_with_wings:'
+
+        input = ':blueEUheart:'
+        output = PostProcessor.new(input).process
+        expect(output).to include ':blue_heart:'
+
+        input = ':non-potableEUwater:'
+        output = PostProcessor.new(input).process
+        expect(output).to include ':non-potable_water:'
+      end
+
       context 'without vertical slides' do
         let :three_slide_input do
           <<-eos

--- a/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper'
 module RevealCK
   module Markdown
     describe PreProcessor do
+      it 'protects _s within emoji by turning them into a temporary token' do
+        input = ':money_with_wings:'
+        output = PreProcessor.new(input).process
+        expect(output).to include ':moneyEUwithEUwings:'
+
+        input = ':blue_heart:'
+        output = PreProcessor.new(input).process
+        expect(output).to include ':blueEUheart:'
+
+        input = ':non-potable_water:'
+        output = PreProcessor.new(input).process
+        expect(output).to include ':non-potableEUwater:'
+      end
+
       let :standard_result do
         <<-eos
 <div>DIVIDER</div>

--- a/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
+++ b/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
@@ -13,6 +13,20 @@ module RevealCK
         template.render
       end
 
+      it 'does not turn _s within a single emoji into <em>s' do
+        output = render_markdown <<-eos
+:money_with_wings:
+eos
+        expect(output).to include ':money_with_wings:'
+      end
+
+      it 'does not turn _s between two emojis into <em>s' do
+        output = render_markdown <<-eos
+:blue_heart: :blue_heart:
+eos
+        expect(output).to include ':blue_heart: :blue_heart:'
+      end
+
       it 'uses "---" to create "<section>"s' do
         output = render_markdown <<-eos
 # h1 Slide


### PR DESCRIPTION
These changes fix issue #29.

reveal-ck has two classes `PreProcessor` and `PostProcessor` that work before and after its embedded markdown processor runs.

This changes makes it so that the `PreProcessor` turns something like `:money_with_wings:` into `:moneyEUwithEUwings:` (where `EU` is a token that stands for `E`moji `U`nderscore, and, more importantly, isn't modified by the markdown processor).

Then the `PostProcessor` does the reverse.

This allows the emoji to reach the next stage of processing-- which is when `RevealCKEmojiFilter` transforms the `:money_with_wings:` into :money_with_wings:

This one's for us, @banderson.