### PR TITLE
HTML-escape special characters in code blocks

### DIFF
--- a/lib/reveal-ck/markdown/slide_markdown.rb
+++ b/lib/reveal-ck/markdown/slide_markdown.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'redcarpet'
 
 module RevealCK
@@ -13,12 +14,13 @@ module RevealCK
       end
 
       def block_code(code, language)
+        escaped = CGI.escape_html(code)
         if language.nil?
-          "<pre><code>#{code}</code></pre>"
+          "<pre><code>#{escaped}</code></pre>"
         elsif language == 'notes' || language == 'note'
-          "<aside class='notes'>#{code}</aside>"
+          "<aside class='notes'>#{escaped}</aside>"
         else
-          "<pre><code class=\"#{language}\">#{code}</code></pre>"
+          "<pre><code class=\"#{language}\">#{escaped}</code></pre>"
         end
       end
     end

--- a/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
+++ b/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
@@ -49,6 +49,17 @@ eos
         expect(output).to include 'a + b'
       end
 
+      it 'converts special characters in ``` block to entity references' do
+        output = render_markdown <<-eos
+```
+<p>"&"</p>
+```
+eos
+        expect(output).to include '<pre><code>'
+        expect(output).to include '</code></pre>'
+        expect(output).to include '&lt;p&gt;&quot;&amp;&quot;&lt;/p&gt;'
+      end
+
       it 'wraps ```ruby code in a <pre> and <code class="ruby">' do
         output = render_markdown <<-eos
 ```ruby


### PR DESCRIPTION
Hi,

I wrote a slides.md that contains the following REPL output:

    ```clojure
    user=> (atom 10)
    #<Atom@6cbda790: 10>
    ```

Then generating HTML slides results in:

    user=> (atom 10)
    #<atom>
    </atom>

That is, `<Atom@6cbda790: 10>` in my slides.md happens to be interpreted as an HTML tag.
I just want my original code block to be shown in browsers as is.

In this pull request I simply escape special characters in code blocks so that they won't be interpreted as tags.
Thanks in advance!