### PR TITLE
[rubocop] Update code to pass latest rubocop preferences

### DIFF
--- a/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
+++ b/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
@@ -7,7 +7,8 @@ module RevealCK
     class ListenToRebuildSlides
       attr_reader :ui, :rebuild_method
       def initialize(ui, &block)
-        @ui, @rebuild_method = ui, block
+        @ui = ui
+        @rebuild_method = block
       end
 
       def run
@@ -25,7 +26,7 @@ module RevealCK
       end
 
       def ignored_files_regex
-        /^slides\/.+$/
+        %r{^slides/.+$}
       end
 
       def message_and_rebuild(mod, add, del)

--- a/lib/reveal-ck/commands/print_banner.rb
+++ b/lib/reveal-ck/commands/print_banner.rb
@@ -6,7 +6,9 @@ module RevealCK
     class PrintBanner
       attr_reader :doc_root, :port, :slides_file, :ui
       def initialize(doc_root, port, slides_file, ui)
-        @doc_root, @port, @slides_file = doc_root, port, slides_file
+        @doc_root = doc_root
+        @port = port
+        @slides_file = slides_file
         @ui = ui
       end
 

--- a/lib/reveal-ck/commands/start_web_server.rb
+++ b/lib/reveal-ck/commands/start_web_server.rb
@@ -8,7 +8,8 @@ module RevealCK
     class StartWebServer
       attr_reader :doc_root, :port
       def initialize(doc_root, port)
-        @doc_root, @port = doc_root, port
+        @doc_root = doc_root
+        @port = port
       end
 
       def run

--- a/lib/reveal-ck/commands/thread_waker.rb
+++ b/lib/reveal-ck/commands/thread_waker.rb
@@ -3,7 +3,8 @@ module RevealCK
     # Utility that wakes up a thread periodically
     class ThreadWaker
       def initialize(thread_to_wake, wait_period = 1)
-        @thread_to_wake, @wait_period = thread_to_wake, wait_period
+        @thread_to_wake = thread_to_wake
+        @wait_period = wait_period
       end
 
       def run

--- a/lib/reveal-ck/presentation.rb
+++ b/lib/reveal-ck/presentation.rb
@@ -28,7 +28,8 @@ module RevealCK
     end
 
     def self.from_template(args)
-      file, config = retrieve(:file, args), retrieve(:config, args)
+      file = retrieve(:file, args)
+      config = retrieve(:config, args)
       presentation = Presentation.new config: config
       template = Templates::Processor.open(file: file, config: config)
       presentation.html = template.output
@@ -36,12 +37,14 @@ module RevealCK
     end
 
     def self.from_dsl(args)
-      file, config = retrieve(:file, args), retrieve(:config, args)
+      file = retrieve(:file, args)
+      config = retrieve(:config, args)
       RevealCK::PresentationDSL.load file: file, config: config
     end
 
     def self.load(args)
-      file, config = retrieve(:file, args), retrieve(:config, args)
+      file = retrieve(:file, args)
+      config = retrieve(:config, args)
       if file.end_with? '.rb'
         Presentation.from_dsl file: file, config: config
       else

--- a/lib/reveal-ck/presentation_dsl.rb
+++ b/lib/reveal-ck/presentation_dsl.rb
@@ -1,3 +1,4 @@
+
 module RevealCK
   #
   # Public: A PresentationDSL defines the DSL behind a
@@ -64,7 +65,8 @@ module RevealCK
     end
 
     def self.load(args)
-      file, config = retrieve(:file, args), retrieve(:config, args)
+      file = retrieve(:file, args)
+      config = retrieve(:config, args)
       builder = PresentationDSL.new config: config
       contents = File.open(file).read
       builder.instance_eval(contents)

--- a/lib/reveal-ck/templates/processor.rb
+++ b/lib/reveal-ck/templates/processor.rb
@@ -15,7 +15,8 @@ module RevealCK
       attr_reader :config
 
       def initialize(args)
-        file, @config = retrieve(:file, args), retrieve(:config, args)
+        @config = retrieve(:config, args)
+        file = retrieve(:file, args)
         @template = Tilt.new file
       end
 
@@ -25,7 +26,8 @@ module RevealCK
       end
 
       def self.open(args)
-        file, config = retrieve(:file, args), retrieve(:config, args)
+        file = retrieve(:file, args)
+        config = retrieve(:config, args)
         Processor.new(file: file, config: config)
       end
     end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_from: ../.rubocop.yml
 Documentation:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 FileName:
   Exclude:
     - lib/reveal-ck_spec.rb

--- a/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
+++ b/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
@@ -10,7 +10,7 @@ module RevealCK
         end
 
         let :generated_slides do
-          /^slides\/.+$/
+          %r{^slides/.+$}
         end
 
         it 'sets up ::Listen to run when things change' do

--- a/spec/lib/reveal-ck/templates/processor_spec.rb
+++ b/spec/lib/reveal-ck/templates/processor_spec.rb
@@ -16,7 +16,7 @@ module RevealCK
       end
 
       let :pretty_printed_basic do
-        /<p>\s+This is basic (Slim|Haml)\s+<\/p>/
+        %r{<p>\s+This is basic (Slim|Haml)\s+</p>}
       end
 
       it 'can process a slim template' do


### PR DESCRIPTION
# Overview

This pull request contains changes that update reveal-ck so that it conforms to the preferences of the latest rubocop release.

## Details

reveal-ck will use the latest rubocop available, and so, as new versions of rubocop are published reveal-ck falls behind.

The changes in this pull request make it so that the code should pass with the latest rubocop.