### PR TITLE
Add "description" and "generator" meta tags

### DIFF
--- a/features/generate-with-config.feature
+++ b/features/generate-with-config.feature
@@ -16,10 +16,11 @@ Feature: The capabilities of config.yml
   Scenario: Generating slides with a template and config.yml
     Given a file named "config.yml" with:
     """
-    title:      "Awesome Title"
-    author:     "Awesome Author"
-    theme:      "night"
-    transition: "page"
+    title:       "Awesome Title"
+    author:      "Awesome Author"
+    theme:       "night"
+    transition:  "page"
+    description: "My beautiful slides"
     """
     Given a file named "slides.haml" with:
     """
@@ -39,6 +40,14 @@ Feature: The capabilities of config.yml
     And the file "slides/index.html" should contain:
     """
     <meta name="author" content="Awesome Author">
+    """
+    And the file "slides/index.html" should contain:
+    """
+    <meta name="description" content="My beautiful slides">
+    """
+    And the file "slides/index.html" should contain:
+    """
+    <meta name="generator" content="reveal-ck
     """
     And the file "slides/index.html" should contain:
     """

--- a/files/reveal-ck/templates/index.html/head.html.erb
+++ b/files/reveal-ck/templates/index.html/head.html.erb
@@ -2,7 +2,7 @@
 
 <title><%= config.title %></title>
 
-<meta name="description" content="A framework for easily creating beautiful presentations using HTML">
+<meta name="description" content="<%= config.description %>">
 <meta name="author" content="<%= config.author %>">
 
 <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/files/reveal-ck/templates/index.html/head.html.erb
+++ b/files/reveal-ck/templates/index.html/head.html.erb
@@ -4,6 +4,7 @@
 
 <meta name="description" content="<%= config.description %>">
 <meta name="author" content="<%= config.author %>">
+<meta name="generator" content="reveal-ck <%= RevealCK::VERSION %>">
 
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -22,10 +22,11 @@ module RevealCK
 
     def core_defaults
       {
-        'title'      => 'Slides',
-        'author'     => '',
-        'theme'      => 'black',
-        'transition' => 'default',
+        'title'       => 'Slides',
+        'description' => '',
+        'author'      => '',
+        'theme'       => 'black',
+        'transition'  => 'default',
         'data' => {
 
         }

--- a/spec/lib/reveal-ck/builders/index_html_spec.rb
+++ b/spec/lib/reveal-ck/builders/index_html_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 module RevealCK
+  VERSION = '1.0'
+
   module Builders
     describe IndexHtml do
       let :index_html_erb do
@@ -40,6 +42,11 @@ module RevealCK
       it 'can render html' do
         expect(rendered_content)
           .to include('<html lang="en">')
+      end
+
+      it 'prints the program name and version in the generator tag' do
+        expect(rendered_content)
+          .to include('<meta name="generator" content="reveal-ck 1.0">')
       end
 
       it 'supports replacing the configured title' do

--- a/spec/lib/reveal-ck/builders/index_html_spec.rb
+++ b/spec/lib/reveal-ck/builders/index_html_spec.rb
@@ -15,6 +15,7 @@ module RevealCK
       let :config do
         config = Config.new
         config.title = 'Sample Title'
+        config.description = 'Sample Description'
         config.author = 'Sample Author'
         config.theme = 'night'
         config.transition = 'page'
@@ -44,6 +45,11 @@ module RevealCK
       it 'supports replacing the configured title' do
         expect(rendered_content)
           .to include('<title>Sample Title</title>')
+      end
+
+      it 'support replacing the configured description' do
+        expect(rendered_content)
+          .to include('<meta name="description" content="Sample Description">')
       end
 
       it 'supports replacing the configured author' do

--- a/spec/lib/reveal-ck/config_spec.rb
+++ b/spec/lib/reveal-ck/config_spec.rb
@@ -34,6 +34,15 @@ module RevealCK
         expect(config.title).to eq 'My Presentation'
       end
 
+      it 'supplies a default description' do
+        expect(config.description).to eq ''
+      end
+
+      it 'supplies a #description, and #description=' do
+        config.description = 'My beautiful slides'
+        expect(config.description).to eq 'My beautiful slides'
+      end
+
       it 'supplies a default transition' do
         expect(config.transition).to eq 'default'
       end


### PR DESCRIPTION
# Overview

This pull request is the same thing as https://github.com/jedcn/reveal-ck/pull/39, but it adds a cucumber/aruba feature that builds out a slide deck when you run the tests, and verifies that the slide deck contains the expected HTML.