### PR TITLE
Use Bundler if it is present

### DIFF
--- a/bin/reveal-ck
+++ b/bin/reveal-ck
@@ -1,4 +1,12 @@
 #!/usr/bin/env ruby
+
+# use Gemfile to load all of user's requirements
+begin
+  require 'bundler'
+  Bundler.require
+rescue LoadException # rubocop:disable Lint/HandleExceptions
+end
+
 require 'gli'
 require 'reveal-ck'
 


### PR DESCRIPTION
When I added a filter that is not part of `reveal-ck`'s gem dependencies, `reveal-ck` does not find the filter. It happens whether or not called with `bundle exec`. While the gem may be in the `LOAD_PATH`, `reveal-ck` never `require`s that filter.

This PR is one possible solution, though 2 others came to mind (at bottom). Let me know your thoughts.

I have a `Gemfile`:

```ruby
source 'https://rubygems.org/'

gem 'reveal-ck'
gem 'html-pipeline-abbr'
```

And I have a `config.yml`:

```yaml
filters:
- "HTML::Pipeline::AbbrFilter"
- "HTML::Pipeline::RevealCKEmojiFilter"
- "HTML::Pipeline::MentionFilter"
- "HTML::Pipeline::AutolinkFilter"
```

---
Alternatives

`reveal-ck -r html-pipeline-abbr generate`

or

```yaml
filters:
- "HTML::Pipeline::ShortenFilter"
- "HTML::Pipeline::RevealCKEmojiFilter"
- "HTML::Pipeline::MentionFilter"
- "HTML::Pipeline::AutolinkFilter"
requires:
- html-pipeline-abbr
```
