### PR TITLE
require an 'init.rb' file if it is available

### DIFF
--- a/lib/reveal-ck/builders/slides_builder.rb
+++ b/lib/reveal-ck/builders/slides_builder.rb
@@ -28,6 +28,7 @@ module RevealCK
       private
 
       def setup
+        load_init
         read_config
         things_to_create.merge(dependencies)
       end
@@ -37,6 +38,12 @@ module RevealCK
         return unless File.exist?(config_file)
         config_as_hash = YAML.load_file config_file
         @config.merge!(config_as_hash)
+      end
+
+      def load_init
+        init_file = File.join(user_dir, 'init.rb')
+        return unless File.exist?(init_file)
+        require init_file
       end
 
       def dependencies


### PR DESCRIPTION
This allows people to require custom files by the name of 'init.rb' as suggested in #44 

I'm starting to think just having a custom rake task would be a better approach.
Then the code would work like the rake task

Ideas