### PR TITLE
Rake task

### DIFF
--- a/lib/reveal-ck/builders/slides_builder.rb
+++ b/lib/reveal-ck/builders/slides_builder.rb
@@ -17,7 +17,7 @@ module RevealCK
         @output_dir = retrieve(:output_dir, args)
         @slides_file = retrieve(:slides_file, args)
         @application = Rake::Application.new
-        @config = Config.new
+        @config = args[:config] || Config.new
         @things_to_create = Set.new
       end
 

--- a/lib/reveal-ck/rake_task.rb
+++ b/lib/reveal-ck/rake_task.rb
@@ -1,0 +1,49 @@
+require 'rake'
+require 'rake/tasklib'
+require_relative '../reveal-ck'
+
+module RevealCK
+  # "generates a reveal presentation"
+  class RakeTask < Rake::TaskLib
+    # the file containing your slide content (defaults to slides.md)
+    attr_accessor :file
+    # the output directory (default slides)
+    attr_accessor :dir
+    attr_accessor :user_dir
+    attr_accessor :gem_dir
+    attr_accessor :stdout_prefix
+    attr_accessor :config
+
+    def initialize(name = :reveal)
+      @name   = name
+      @file = FileList['slides.*'].first
+      @dir = 'slides'
+      @user_dir = Dir.pwd
+      @gem_dir = RevealCK.path
+      @stdout_prefix = ''
+      @config = Config.new
+      yield self if block_given?
+      define
+    end
+
+    def define
+      desc "generate a reveal slideshow"
+      task @name do
+        msg = "Generating slides for '#{file}'.."
+        msg = "#{stdout_prefix} #{msg}" unless stdout_prefix.empty?
+        puts msg
+
+        slides_builder = RevealCK::Builders::SlidesBuilder.new(
+          user_dir: user_dir,
+          gem_dir: gem_dir,
+          output_dir: dir,
+          slides_file: file,
+          stdout_prefix: stdout_prefix,
+          config: config,
+        )
+        slides_builder.prepare
+        slides_builder.build
+      end
+    end
+  end
+end

--- a/lib/reveal-ck/rake_task.rb
+++ b/lib/reveal-ck/rake_task.rb
@@ -1,48 +1,62 @@
 require 'rake'
 require 'rake/tasklib'
-require_relative '../reveal-ck'
+require 'reveal-ck'
 
 module RevealCK
   # "generates a reveal presentation"
   class RakeTask < Rake::TaskLib
-    # the file containing your slide content (defaults to slides.md)
+    include ::Rake::DSL if defined?(::Rake::DSL)
+
+    # Name of task.
+    # Defauts to `:reveal`.
+    attr_accessor :name
+
+    # the file containing your slide content.
+    # Defaults to `'slides.md'`.
     attr_accessor :file
-    # the output directory (default slides)
+
+    # the output directory
+    # Defaults to `'slides'`.
     attr_accessor :dir
     attr_accessor :user_dir
     attr_accessor :gem_dir
-    attr_accessor :stdout_prefix
     attr_accessor :config
 
-    def initialize(name = :reveal)
-      @name   = name
-      @file = FileList['slides.*'].first
-      @dir = 'slides'
-      @user_dir = Dir.pwd
-      @gem_dir = RevealCK.path
-      @stdout_prefix = ''
-      @config = Config.new
+    def initialize(*args, &task_block)
+      @name          = args.shift || :reveal
+      @file          = FileList['slides.*'].first
+      @dir           = 'slides'
+      @user_dir      = Dir.pwd
+      @gem_dir       = RevealCK.path
+      @config        = Config.new
       yield self if block_given?
-      define
+      define(args, &task_block)
     end
 
-    def define
-      desc "generate a reveal slideshow"
-      task @name do
-        msg = "Generating slides for '#{file}'.."
-        msg = "#{stdout_prefix} #{msg}" unless stdout_prefix.empty?
-        puts msg
+    # @private
+    def run_task(verbose)
+      puts "Generating slides for '#{file}'.." if verbose
 
-        slides_builder = RevealCK::Builders::SlidesBuilder.new(
-          user_dir: user_dir,
-          gem_dir: gem_dir,
-          output_dir: dir,
-          slides_file: file,
-          stdout_prefix: stdout_prefix,
-          config: config,
-        )
-        slides_builder.prepare
-        slides_builder.build
+      slides_builder = RevealCK::Builders::SlidesBuilder.new(
+        user_dir:      user_dir,
+        gem_dir:       gem_dir,
+        output_dir:    dir,
+        slides_file:   file,
+        config:        config
+      )
+      slides_builder.prepare
+      slides_builder.build
+    end
+
+    def define(args, &task_block)
+      desc 'Generate a reveal slideshow' unless ::Rake.application.last_comment
+      task name, *args do |_, task_args|
+        RakeFileUtils.__send__(:verbose, verbose) do
+          if task_block
+            task_block.call(*[self, task_args].slice(0, task_block.arity))
+          end
+          run_task verbose
+        end
       end
     end
   end


### PR DESCRIPTION
I added a `RakeTask` and like this approach more than #44 and #49
This is what I'm using in the short term.

I call with `bundle exec rake reveal` and have the following `Gemfile` and `Rakefile`:

```ruby
source 'https://rubygems.org/'

# gem 'reveal-ck' # I need my new rake task
gem 'reveal-ck', path: "../../gems/reveal-ck"
gem 'html-pipeline-abbr'
```

```ruby
require 'reveal-ck/rake_task'
require 'html/pipeline/abbr'

RevealCK::RakeTask.new do |t|
  t.dir = 'custom'
  t.config.filters = %w(
    HTML::Pipeline::AutoAbbrFilter
    HTML::Pipeline::AbbrEmojiFilter
    HTML::Pipeline::MentionFilter
    HTML::Pipeline::AutolinkFilter
  )
end
```

1. The values in `config.yml` take precedence over these values.
2. I can also add delegates for the config methods.
3. I could add tests based upon rspec's task tests.
4. I would prefer you muck around with the config if you wanted to support `config.yml` and rake params and have the rake params take precedence over the `config.yml` ones.
