### PR TITLE
Allow config file to specify requires for filters

### DIFF
--- a/features/generate-with-config.feature
+++ b/features/generate-with-config.feature
@@ -94,6 +94,41 @@ Feature: The capabilities of config.yml
     transition: 'page'
     """
 
+  Scenario: Generating slides with custom filters and requires
+    Given a file named "config.yml" with:
+    """
+    filters:
+      - 'HTML::Pipeline::ItsFilter'
+    requires:
+      - './its_filter'
+    """
+    And a file named "its_filter.rb" with:
+    """
+    module HTML
+      class Pipeline
+        class ItsFilter < TextFilter
+          def call
+            # Certain people prefer to say "It is" rather than "It's"
+            @text.gsub(/It&#39;s/, 'It is')
+          end
+        end
+      end
+    end
+    """
+    And a file named "slides.md" with:
+    """
+    It's not professional.
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.md'..\n"
+    And the following files should exist:
+    | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <p>It is not professional.</p>
+    """
+
   Scenario: Referencing config data with a templating language
     Given a file named "config.yml" with:
     """

--- a/lib/reveal-ck/builders/create_slides_html.rb
+++ b/lib/reveal-ck/builders/create_slides_html.rb
@@ -36,12 +36,17 @@ module RevealCK
       end
 
       def apply_filters_to(html)
+        load_dependencies(config.requires)
         filters = get_classes_from_array(config.filters)
         pipeline = HTML::Pipeline.new(filters)
         filtered_html_string = FilteredHtmlString.new(html: html,
                                                       config: config.to_h,
                                                       pipeline: pipeline)
         filtered_html_string.render
+      end
+
+      def load_dependencies(array_of_includes)
+        array_of_includes.each { |name| require name }
       end
 
       def get_classes_from_array(array_of_names)

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -50,7 +50,8 @@ module RevealCK
                       'HTML::Pipeline::MentionFilter',
                       'HTML::Pipeline::AutolinkFilter'],
         'asset_root' => 'https://assets-cdn.github.com/images/icons/',
-        'base_url' => 'https://github.com'
+        'base_url' => 'https://github.com',
+        'requires' => []
       }
     end
   end

--- a/spec/lib/reveal-ck/builders/create_slides_html_spec.rb
+++ b/spec/lib/reveal-ck/builders/create_slides_html_spec.rb
@@ -54,6 +54,31 @@ module RevealCK
           end
         end
       end
+
+      it 'requires the entries in config.filters' do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            slides_file_initial = 'slides-initial.md'
+            File.open(slides_file_initial, 'w') do |file|
+              file.puts('# Slides')
+            end
+
+            config = Config.new
+            config.requires = %w(json time)
+            application = Rake::Application.new
+            slides_html =
+              CreateSlidesHtml.new(slides_file: slides_file_initial,
+                                   output_dir: dir,
+                                   config: config,
+                                   application: application)
+
+            slides_html.prepare
+            expect(slides_html).to receive(:require).with('json')
+            expect(slides_html).to receive(:require).with('time')
+            application['create_slides_html'].invoke
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I like the rake task and will keep iterating on it.

I feel the filter in `config.yml` is more useful if a user can also say 'here is where you can find these filters'

This allows you to add a require block in the config to do that

(the rake task broke down when I wanted to serve up the assets. so I still need this, bundler, or `init.rb`