### PR TITLE
default output director to slide name

### DIFF
--- a/bin/reveal-ck
+++ b/bin/reveal-ck
@@ -11,14 +11,12 @@ class RevealCKExecutable
 
   desc 'Generate reveal.js slides'
   command :generate do |c|
-    slide_files = FileList['slides.*']
-    default_file = slide_files.empty? ? nil : slide_files.first
-
+    default_file = FileList['slides.*'].first
     c.desc 'The file containing your slide content'
     c.flag [:f, :file], default_value: default_file
 
-    c.desc 'The directory to place your generated slides in'
-    c.flag [:d, :dir], default_value: 'slides'
+    c.desc 'The directory for the generated slides. name based upon slide file'
+    c.flag [:d, :dir]
 
     c.action do |_, options, _|
       slides_file = options[:file]
@@ -36,11 +34,13 @@ class RevealCKExecutable
         msg = 'Create a file matching slides.* to proceed, such as slides.md.'
         exit_now!(msg)
       end
+      slides_dir = options[:dir] || options[:file].sub(%r{\.[^/]*\z}, '')
+
       generate_args = {
         user_dir: Dir.pwd,
         gem_dir: RevealCK.path,
-        output_dir: options[:dir],
-        slides_file: options[:file]
+        output_dir: slides_dir,
+        slides_file: slides_file
       }
       RevealCK::Commands::Generate.new(generate_args).run
     end
@@ -48,14 +48,12 @@ class RevealCKExecutable
 
   desc 'Start webserver so slides are available via http'
   command :serve, :server do |c|
-    slide_files = FileList['slides.*']
-    default_file = slide_files.empty? ? nil : slide_files.first
-
+    default_file = FileList['slides.*'].first
     c.desc 'The file containing your slide content'
     c.flag [:f, :file], default_value: default_file
 
-    c.desc 'The directory to serve up'
-    c.flag [:d, :dir], default_value: 'slides'
+    c.desc 'The directory to serve up. name based upon slide file'
+    c.flag [:d, :dir]
 
     c.desc 'The port to serve on'
     c.flag [:p, :port], default_value: 10_000
@@ -64,10 +62,11 @@ class RevealCKExecutable
     c.flag ['test-quit-after-starting'], type: Integer
 
     c.action do |_, options, _|
+      slides_dir = options[:dir] || options[:file].sub(%r{\.[^/]*\z}, '')
       serve_args = {
-        doc_root: options[:dir],
+        doc_root: slides_dir,
         gem_dir: RevealCK.path,
-        output_dir: options[:dir],
+        output_dir: slides_dir,
         port: options[:port],
         slides_file: options[:file],
         user_dir: Dir.pwd

--- a/features/generate-with-alt-dir.feature
+++ b/features/generate-with-alt-dir.feature
@@ -1,0 +1,43 @@
+Feature: reveal-ck generate --dir
+
+  By default, `reveal-ck generate` creates slides in a directory named after the slide file.
+
+  And this is known as your 'slides directory.'
+
+  The slide directory from a slide file named 'slides.md' or 'slides.textile' will be 'slides.'
+
+  However, if you'd prefer, you can create an alternate directory
+  `slides_for_google_talk` and have reveal-ck use that instead. To
+  do this, you'd say:
+
+      reveal-ck generate --directory 'slides_for_google_talk'
+
+  Scenario: Generating custom slide directory
+    Given a file named "slides.haml" with:
+    """
+    %section
+      %h2
+        Uh oh!
+
+    %section
+      %h3
+        Guess what day it is?
+
+    %section
+      %h3
+        Guess what day it is!
+
+    %section
+      %h3
+        Huh?
+
+    %section
+      %h3
+        Anybody?
+    """
+    When I run `reveal-ck generate --dir slides_for_google_talk`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.haml'..\n"
+    And the following files should exist:
+    | slides_for_google_talk/slides.html |
+    | slides_for_google_talk/index.html  |

--- a/features/generate-with-alt-file.feature
+++ b/features/generate-with-alt-file.feature
@@ -17,7 +17,7 @@ Feature: reveal-ck generate --file
       reveal-ck generate --file 'slides_for_google_talk.md'
 
   Scenario: Generating basic slides any file
-    Given a file named "hump-day.haml" with:
+    Given a file named "slides_for_google_talk.haml" with:
     """
     %section
       %h2
@@ -39,9 +39,9 @@ Feature: reveal-ck generate --file
       %h3
         Anybody?
     """
-    When I run `reveal-ck generate --file hump-day.haml`
+    When I run `reveal-ck generate --file slides_for_google_talk.haml`
     Then the exit status should be 0
-    And the output should contain exactly "Generating slides for 'hump-day.haml'..\n"
+    And the output should contain exactly "Generating slides for 'slides_for_google_talk.haml'..\n"
     And the following files should exist:
-    | slides/slides.html |
-    | slides/index.html  |
+    | slides_for_google_talk/slides.html |
+    | slides_for_google_talk/index.html  |


### PR DESCRIPTION
I was trying to share the problem I was running into in #52 but realized it would be easier to share as a diff.

I like the current output of the command that says "defaults to sample"

Not sure how to fix that. I guess adding in text into the description works, but want your input