### PR TITLE
Silence rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,11 @@ CyclomaticComplexity:
 
 AllCops:
   Include:
-    - Rakefile
+    - '**/Rakefile'
     - rakelib/*.rake
   Exclude:
     - tmp/**/*
+    - files/reveal.js/**/*
 
 Encoding:
   EnforcedStyle: when_needed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ SimpleCov.start do
   ]
 end
 
+# silence tilt autoload warnings
+require 'tilt/erb'
+require 'tilt/haml'
+
 require_relative '../lib/reveal-ck'
 
 RSpec.configure do |config|


### PR DESCRIPTION
3 small things.

1. rubocop was running on reveal.js files.
This made my build blowup locally
This removes that. (but added a deprecation warning that I can't figure out)

2. It was complaining that Rakefile was a deprecated pattern
This fixes that.

3. Tilt was complaining that requiring erb and haml are not thread safe.
This adds them to the `spec_helper.rb`
For this same reason, I have a `require: 'tilt/erb'` in my local `config.yml` file.

Thanks
--K