### PR TITLE
emoji css

### DIFF
--- a/files/reveal-ck/css/reveal-ck.css
+++ b/files/reveal-ck/css/reveal-ck.css
@@ -1,6 +1,10 @@
 .reveal section img.emoji {
+    position: relative;
     background: none;
     border: 0;
     box-shadow: none;
+    vertical-align:middle;
     margin: 0;
+    margin-bottom:.25em;
+    display:inline-block;
 }

--- a/lib/html/pipeline/reveal_ck_emoji_filter.rb
+++ b/lib/html/pipeline/reveal_ck_emoji_filter.rb
@@ -1,15 +1,14 @@
 module HTML
   class Pipeline
     # This class is very similar EmojiFilter. It removes the inline
-    # width/height attributes so that reveal-ck supplied CSS takes effect.
+    # width/height/align attributes so that reveal-ck supplied CSS takes effect.
     class RevealCKEmojiFilter < EmojiFilter
       def emoji_image_filter(text)
         return text unless text.include?(':')
 
         text.gsub(emoji_pattern) do
           name = Regexp.last_match[1]
-          result = "<img class='emoji' title=':#{name}:' alt=':#{name}:' "
-          result + "src='#{emoji_url(name)}' align='absmiddle' />"
+          "<img class='emoji' alt=':#{name}:' src='#{emoji_url(name)}' />"
         end
       end
     end

--- a/spec/lib/html/pipeline/reveal_ck_emoji_filter_spec.rb
+++ b/spec/lib/html/pipeline/reveal_ck_emoji_filter_spec.rb
@@ -12,9 +12,9 @@ module HTML
       end
 
       it 'works with defined emoji' do
-        expected = "I <img class='emoji' title=':heart:' "
+        expected = "I <img class='emoji' "
         expected += "alt=':heart:' src='asset_root/emoji/unicode/2764.png' "
-        expected += "align='absmiddle' /> emoji"
+        expected += "/> emoji"
         result = emoji_filter.emoji_image_filter('I :heart: emoji')
         expect(result).to eq(expected)
       end


### PR DESCRIPTION
This is the css I'm using for emoji.

I also removed `align` and `title` from the emoji img tag. Can put `title` back in if you prefer.

(Still working through my own emoji filter that outputs unicode instead of `img` tags in certain cases)