### PR TITLE
Create PR and Issue Templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Hello! And thanks for opening up an issue!
+
+We're sorry things aren't working as you expected.
+
+If you open up an issue and describe what's wrong we'll take a look.
+
+Please delete this introductory text before you open the issue.
+
+# Overview
+
+What is wrong?
+
+It's ok to:
+
+* Call out something that is not working as you would expect
+* Describe something you wish existed
+* Ask a general question about reveal.js or slides

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Hello! And thanks for opening up a pull request!
+
+Please..
+
+* Delete this introductory text before you open the PR.
+* Understand that we follow [Thoughtbot's Guidelines for Code Reviews][thoughtbot-codereview].
+
+[thoughtbot-codereview]: https://github.com/thoughtbot/guides/tree/master/code-review
+
+# Overview
+
+In a sentence or two, what are you changing and what is the core
+motivation for the change?
+
+## Details
+
+If appropriate..
+
+* Please provide some background or any trade offs that you
+  considered.
+* What testing have you done? Do you have any concerns?


### PR DESCRIPTION
# Overview

Github recently allowed people to supply templates for pull requests and issues: https://github.com/blog/2111-issue-and-pull-request-templates.

And this PR does just that.