### PR TITLE
Build for directories with special characters

### DIFF
--- a/lib/reveal-ck/builders/copy_files_task.rb
+++ b/lib/reveal-ck/builders/copy_files_task.rb
@@ -17,7 +17,8 @@ module RevealCK
       end
 
       def analyze_file(file)
-        dest = file.pathmap("%{^#{file_listing.dir}/,#{output_dir}/}p")
+        src_dir = Regexp.escape(file_listing.dir)
+        dest = file.pathmap("%{^#{src_dir}/,#{output_dir}/}p")
         copy_file(file, dest)
         dest_dir = dest.pathmap('%d')
         create_directory(dest_dir)

--- a/spec/lib/reveal-ck/builders/copy_files_task_spec.rb
+++ b/spec/lib/reveal-ck/builders/copy_files_task_spec.rb
@@ -68,6 +68,28 @@ module RevealCK
 
         task.prepare
       end
+
+      context 'with a funky directory name' do
+        let :source_dir do
+          'fun+trouble'
+        end
+
+        it 'creates the files from the file_listing' do
+          task = CopyFilesTask.new(application: Rake::Application.new,
+                                   file_listing: file_listing,
+                                   output_dir: destination_directory)
+
+          expect(task)
+            .to receive(:copy_file)
+            .with(file_a_source, file_a_destination)
+
+          expect(task)
+            .to receive(:copy_file)
+            .with(file_b_source, file_b_destination)
+
+          task.prepare
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Yay. presentation time again... :)
Thanks for the great tool

# Overview

Escape the slide directory name so it doesnt cause errors with regular expression matches.
This was blowing up with a slide deck called `n+1`

## Details

Only concern is there are other places in the code that don't properly escape
user input (e.g.: guard). but that is beyond the scope of this pr.

It now works for my directory and I added a spec.
If you prefer just changing the original spec's source directory name or a different approach, just give out a shout.
