### PR TITLE
Support Markdown in notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ bugs are fixed.
 
 ### Added
 
-* Nothing.
+* You can now use Markdown in slide notes.
 
 ### Changed
 

--- a/features/generate-with-markdown.feature
+++ b/features/generate-with-markdown.feature
@@ -385,3 +385,18 @@ Feature: Slides with markdown
     """
     #&lt;Atom@6cbda790: 10&gt;
     """
+
+  Scenario: Creating a slide with notes that contain markdown
+    Given a file named "slides.md" with:
+    """
+    # Hello There!
+
+    ```notes
+    Remember to *smile*
+    ```
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the file "slides/index.html" should have html matching the xpath:
+    | //section/aside[contains(., "Remember to smile")] | the note to remember |
+    | //section/aside/p/em[contains(., "smile")]        | smile is in <em>s    |

--- a/lib/reveal-ck/markdown/slide_markdown.rb
+++ b/lib/reveal-ck/markdown/slide_markdown.rb
@@ -18,7 +18,9 @@ module RevealCK
         if language.nil?
           "<pre><code>#{escaped}</code></pre>"
         elsif language == 'notes' || language == 'note'
-          "<aside class='notes'>#{escaped}</aside>"
+          markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+          notes = markdown.render(escaped)
+          "<aside class='notes'>#{notes}</aside>"
         else
           "<pre><code class=\"#{language}\">#{escaped}</code></pre>"
         end


### PR DESCRIPTION
# Overview

This change makes it so that you can write your notes in markdown. See the associate `.feature` file change for an example.

It's motivated in response to #68.
## Details

I wrote a failing feature first, and then I made the feature pass. I haven't done much more than that.
