### PR TITLE
Add host option to serve on other than localhost

### DIFF
--- a/bin/reveal-ck
+++ b/bin/reveal-ck
@@ -59,6 +59,9 @@ class RevealCKExecutable
     c.desc 'The port to serve on'
     c.flag [:p, :port], default_value: 10_000
 
+    c.desc 'The host to serve on'
+    c.flag [:h, :host], default_value: 'localhost'
+
     c.desc 'Exit after starting + n seconds (for testing only)'
     c.flag ['test-quit-after-starting'], type: Integer
 
@@ -69,6 +72,7 @@ class RevealCKExecutable
         gem_dir: RevealCK.path,
         output_dir: slides_dir,
         port: options[:port],
+        host: options[:host],
         slides_file: options[:file],
         user_dir: Dir.pwd
       }

--- a/lib/reveal-ck/commands/print_banner.rb
+++ b/lib/reveal-ck/commands/print_banner.rb
@@ -4,10 +4,11 @@ module RevealCK
     # sent explain everything to do with the serve command (listening,
     # reloading, and webserving)
     class PrintBanner
-      attr_reader :doc_root, :port, :slides_file, :ui
-      def initialize(doc_root, port, slides_file, ui)
+      attr_reader :doc_root, :port, :host, :slides_file, :ui
+      def initialize(doc_root, port, host, slides_file, ui)
         @doc_root = doc_root
         @port = port
+        @host = host
         @slides_file = slides_file
         @ui = ui
       end
@@ -15,7 +16,7 @@ module RevealCK
       def run
         ui.separator
         ui.message "Serving up slide content in '#{doc_root}/'."
-        ui.message "Open your browser to 'http://localhost:#{port}'."
+        ui.message "Open your browser to 'http://#{host}:#{port}'."
         ui.message 'Press CTRL-C to stop.'
         ui.separator
       end

--- a/lib/reveal-ck/commands/serve.rb
+++ b/lib/reveal-ck/commands/serve.rb
@@ -10,9 +10,9 @@ module RevealCK
       attr_reader :slides_file, :user_dir, :gem_dir, :output_dir
       attr_reader :ui
       def initialize(args)
-        @host	     = retrieve(:host, args)
         @doc_root    = retrieve(:doc_root, args)
         @port        = retrieve(:port, args)
+        @host        = retrieve(:host, args)
         @slides_file = retrieve(:slides_file, args)
         @gem_dir     = retrieve(:gem_dir, args)
         @output_dir  = retrieve(:output_dir, args)

--- a/lib/reveal-ck/commands/serve.rb
+++ b/lib/reveal-ck/commands/serve.rb
@@ -6,10 +6,11 @@ module RevealCK
     # This includes taking an action and managing stdout
     class Serve
       include Retrieve
-      attr_reader :doc_root, :port
+      attr_reader :doc_root, :port, :host
       attr_reader :slides_file, :user_dir, :gem_dir, :output_dir
       attr_reader :ui
       def initialize(args)
+        @host	     = retrieve(:host, args)
         @doc_root    = retrieve(:doc_root, args)
         @port        = retrieve(:port, args)
         @slides_file = retrieve(:slides_file, args)
@@ -35,7 +36,7 @@ module RevealCK
       private
 
       def print_banner
-        PrintBanner.new(doc_root, port, slides_file, ui).run
+        PrintBanner.new(doc_root, port, host, slides_file, ui).run
       end
 
       def listen_to_reload
@@ -52,7 +53,7 @@ module RevealCK
 
       def start_web_server
         ui.message('Starting Webserver.')
-        StartWebServer.new(doc_root, port).run
+        StartWebServer.new(doc_root, port, host).run
       end
 
       def rebuild_options

--- a/lib/reveal-ck/commands/start_web_server.rb
+++ b/lib/reveal-ck/commands/start_web_server.rb
@@ -6,14 +6,16 @@ module RevealCK
   module Commands
     # The idea of starting up a webserver to display slides locally.
     class StartWebServer
-      attr_reader :doc_root, :port
-      def initialize(doc_root, port)
+      attr_reader :doc_root, :port, :host
+      def initialize(doc_root, port, host)
         @doc_root = doc_root
         @port = port
+        @host = host
       end
 
       def run
         Rack::Server.new(app: build_rack_app(doc_root),
+                         Host: host,
                          Port: port,
                          Logger: server_log,
                          DoNotReverseLookup: true,

--- a/spec/lib/reveal-ck/commands/print_banner_spec.rb
+++ b/spec/lib/reveal-ck/commands/print_banner_spec.rb
@@ -15,7 +15,7 @@ module RevealCK
             .to(receive(:message))
             .at_least :once
 
-          banner = PrintBanner.new('doc_root', 'port', 'slides_file', serve_ui)
+          banner = PrintBanner.new('doc_root', 'port', 'host', 'slides_file', serve_ui)
           banner.run
         end
       end

--- a/spec/lib/reveal-ck/commands/serve_spec.rb
+++ b/spec/lib/reveal-ck/commands/serve_spec.rb
@@ -5,6 +5,7 @@ def build_serve
   RevealCK::Commands::Serve
     .new(doc_root: 'doc_root',
          port: 'port',
+         host: 'host',
          user_dir: 'user_dir',
          gem_dir: 'gem_dir',
          output_dir: 'output_dir',
@@ -74,7 +75,7 @@ module RevealCK
           print_banner = double
           expect(PrintBanner)
             .to(receive(:new))
-            .with('doc_root', 'port', 'slides_file', serve_ui)
+            .with('doc_root', 'port', 'host', 'slides_file', serve_ui)
             .and_return(print_banner)
           expect(print_banner)
             .to(receive(:run))

--- a/spec/lib/reveal-ck/commands/start_web_server_spec.rb
+++ b/spec/lib/reveal-ck/commands/start_web_server_spec.rb
@@ -7,7 +7,7 @@ module RevealCK
       describe '#run' do
         it 'works with Rack to start an application' do
           start_web_server =
-            StartWebServer.new('doc_root', 'port')
+            StartWebServer.new('doc_root', 'port', 'host')
           rack_server = double
           expect(::Rack::Server)
             .to(receive(:new))


### PR DESCRIPTION
I wanted an option to do serve on a other IP-address that localhost. This change make it possible to add -h / --host option te set a different IP-adress the webserver will listen on.

I have made the change quite simple. My ruby knowledge is not great and I have not tested the change fully. I could not get the spec-test working and have not changed it. I tested that it was running on 0.0.0.0 when I run ```reveal-ck serve -h 0.0.0.0``` and it did. Also the banner is printing the current address specified by -h.