### PR TITLE
Specify host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ bugs are fixed.
 
 ### Added
 
-* Nothing
+* When running `reveal-ck serve`, you can now specify the host you'd
+  like to use. `reveal-ck` still defaults to localhost, but you can
+  supply values like 0.0.0.0. See
+  https://github.com/jedcn/reveal-ck/pull/79 for details.
 
 ### Changed
 

--- a/bin/reveal-ck
+++ b/bin/reveal-ck
@@ -59,6 +59,9 @@ class RevealCKExecutable
     c.desc 'The port to serve on'
     c.flag [:p, :port], default_value: 10_000
 
+    c.desc 'The host to serve on'
+    c.flag [:h, :host], default_value: 'localhost'
+
     c.desc 'Exit after starting + n seconds (for testing only)'
     c.flag ['test-quit-after-starting'], type: Integer
 
@@ -69,6 +72,7 @@ class RevealCKExecutable
         gem_dir: RevealCK.path,
         output_dir: slides_dir,
         port: options[:port],
+        host: options[:host],
         slides_file: options[:file],
         user_dir: Dir.pwd
       }

--- a/features/serve.feature
+++ b/features/serve.feature
@@ -22,7 +22,7 @@ Feature: Using 'reveal-ck serve'
     """
     # reveal-ck serve
     """
-    When I temporarily start reveal-ck serve
+    When I temporarily start reveal-ck serve with host "localhost"
     Then the exit status should be 1
     # The banner prints..
     And the output should contain "[ reveal-ck ] Serving up slide content in 'slides/'."
@@ -34,3 +34,13 @@ Feature: Using 'reveal-ck serve'
     And the output should contain "[ reveal-ck ] Starting Webserver."
     # We're ready to reload
     And the output should contain "[   reload  ] Guard is now watching"
+
+  Scenario: Starting up `reveal-ck serve` and specifying a host
+    Given a file named "slides.md" with:
+    """
+    # reveal-ck serve
+    """
+    When I temporarily start reveal-ck serve with host "0.0.0.0"
+    Then the exit status should be 1
+    # The banner prints..
+    And the output should contain "[ reveal-ck ] Open your browser to 'http://0.0.0.0"

--- a/features/step_definitions/serve_steps.rb
+++ b/features/step_definitions/serve_steps.rb
@@ -1,4 +1,5 @@
-When(/^I temporarily start reveal\-ck serve$/) do
+When(/^I temporarily start reveal\-ck serve with host "(.*?)"$/) do |host|
   port = 10_000 + rand(1000)
-  run("reveal-ck serve --port #{port} --test-quit-after-starting 2")
+  cmd = "reveal-ck serve --port #{port} --host #{host}"
+  run("#{cmd} --test-quit-after-starting 2")
 end

--- a/lib/reveal-ck/commands/print_banner.rb
+++ b/lib/reveal-ck/commands/print_banner.rb
@@ -4,10 +4,11 @@ module RevealCK
     # sent explain everything to do with the serve command (listening,
     # reloading, and webserving)
     class PrintBanner
-      attr_reader :doc_root, :port, :slides_file, :ui
-      def initialize(doc_root, port, slides_file, ui)
+      attr_reader :doc_root, :port, :host, :slides_file, :ui
+      def initialize(doc_root, port, host, slides_file, ui)
         @doc_root = doc_root
         @port = port
+        @host = host
         @slides_file = slides_file
         @ui = ui
       end
@@ -15,7 +16,7 @@ module RevealCK
       def run
         ui.separator
         ui.message "Serving up slide content in '#{doc_root}/'."
-        ui.message "Open your browser to 'http://localhost:#{port}'."
+        ui.message "Open your browser to 'http://#{host}:#{port}'."
         ui.message 'Press CTRL-C to stop.'
         ui.separator
       end

--- a/lib/reveal-ck/commands/serve.rb
+++ b/lib/reveal-ck/commands/serve.rb
@@ -6,12 +6,13 @@ module RevealCK
     # This includes taking an action and managing stdout
     class Serve
       include Retrieve
-      attr_reader :doc_root, :port
+      attr_reader :doc_root, :port, :host
       attr_reader :slides_file, :user_dir, :gem_dir, :output_dir
       attr_reader :ui
       def initialize(args)
         @doc_root    = retrieve(:doc_root, args)
         @port        = retrieve(:port, args)
+        @host        = retrieve(:host, args)
         @slides_file = retrieve(:slides_file, args)
         @gem_dir     = retrieve(:gem_dir, args)
         @output_dir  = retrieve(:output_dir, args)
@@ -35,7 +36,7 @@ module RevealCK
       private
 
       def print_banner
-        PrintBanner.new(doc_root, port, slides_file, ui).run
+        PrintBanner.new(doc_root, port, host, slides_file, ui).run
       end
 
       def listen_to_reload
@@ -52,7 +53,7 @@ module RevealCK
 
       def start_web_server
         ui.message('Starting Webserver.')
-        StartWebServer.new(doc_root, port).run
+        StartWebServer.new(doc_root, port, host).run
       end
 
       def rebuild_options

--- a/lib/reveal-ck/commands/start_web_server.rb
+++ b/lib/reveal-ck/commands/start_web_server.rb
@@ -6,14 +6,16 @@ module RevealCK
   module Commands
     # The idea of starting up a webserver to display slides locally.
     class StartWebServer
-      attr_reader :doc_root, :port
-      def initialize(doc_root, port)
+      attr_reader :doc_root, :port, :host
+      def initialize(doc_root, port, host)
         @doc_root = doc_root
         @port = port
+        @host = host
       end
 
       def run
         Rack::Server.new(app: build_rack_app(doc_root),
+                         Host: host,
                          Port: port,
                          Logger: server_log,
                          DoNotReverseLookup: true,

--- a/spec/lib/reveal-ck/commands/print_banner_spec.rb
+++ b/spec/lib/reveal-ck/commands/print_banner_spec.rb
@@ -15,7 +15,8 @@ module RevealCK
             .to(receive(:message))
             .at_least :once
 
-          banner = PrintBanner.new('doc_root', 'port', 'host', 'slides_file', serve_ui)
+          banner = PrintBanner.new('doc_root', 'port', 'host', 'slides_file',
+                                   serve_ui)
           banner.run
         end
       end

--- a/spec/lib/reveal-ck/commands/print_banner_spec.rb
+++ b/spec/lib/reveal-ck/commands/print_banner_spec.rb
@@ -15,7 +15,7 @@ module RevealCK
             .to(receive(:message))
             .at_least :once
 
-          banner = PrintBanner.new('doc_root', 'port', 'slides_file', serve_ui)
+          banner = PrintBanner.new('doc_root', 'port', 'host', 'slides_file', serve_ui)
           banner.run
         end
       end

--- a/spec/lib/reveal-ck/commands/serve_spec.rb
+++ b/spec/lib/reveal-ck/commands/serve_spec.rb
@@ -5,6 +5,7 @@ def build_serve
   RevealCK::Commands::Serve
     .new(doc_root: 'doc_root',
          port: 'port',
+         host: 'host',
          user_dir: 'user_dir',
          gem_dir: 'gem_dir',
          output_dir: 'output_dir',
@@ -74,7 +75,7 @@ module RevealCK
           print_banner = double
           expect(PrintBanner)
             .to(receive(:new))
-            .with('doc_root', 'port', 'slides_file', serve_ui)
+            .with('doc_root', 'port', 'host', 'slides_file', serve_ui)
             .and_return(print_banner)
           expect(print_banner)
             .to(receive(:run))

--- a/spec/lib/reveal-ck/commands/start_web_server_spec.rb
+++ b/spec/lib/reveal-ck/commands/start_web_server_spec.rb
@@ -7,7 +7,7 @@ module RevealCK
       describe '#run' do
         it 'works with Rack to start an application' do
           start_web_server =
-            StartWebServer.new('doc_root', 'port')
+            StartWebServer.new('doc_root', 'port', 'host')
           rack_server = double
           expect(::Rack::Server)
             .to(receive(:new))


### PR DESCRIPTION
# Overview

This PR is based on #79.

It re-uses @scornelissen85 initial commit and adds two more administrative ones.

You can now supply a `--host` when starting up `reveal-ck serve`.