### PR TITLE
Supports OGP meta tag contents

### DIFF
--- a/features/generate-with-config.feature
+++ b/features/generate-with-config.feature
@@ -170,3 +170,47 @@ Feature: The capabilities of config.yml
     | slides/index.html  |
     And the file "slides/index.html" should have html matching the css:
     | img[src*="reveal-js/reveal-parallax-1.jpg"]  | the referenced image |
+
+  Scenario: Generating slides with a template and og configs
+    Given a file named "config.yml" with:
+    """
+    meta_properties:
+      og:title: "reveal-ck"
+    """
+    Given a file named "slides.haml" with:
+    """
+    %section
+      %p
+        Config
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.haml'..\n"
+    And the following files should exist:
+      | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <meta property="og:title" content="reveal-ck" />
+    """
+
+  Scenario: Generating slides with a template and twitter configs
+    Given a file named "config.yml" with:
+    """
+    meta_names:
+      twitter:title: "reveal-ck"
+    """
+    Given a file named "slides.haml" with:
+    """
+    %section
+      %p
+        Config
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.haml'..\n"
+    And the following files should exist:
+      | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <meta name="twitter:title" content="reveal-ck" />
+    """

--- a/files/reveal-ck/templates/index.html/head.html.erb
+++ b/files/reveal-ck/templates/index.html/head.html.erb
@@ -6,6 +6,14 @@
 <meta name="author" content="<%= config.author %>">
 <meta name="generator" content="reveal-ck <%= RevealCK::VERSION %>">
 
+<% config.meta_properties.each do |property, content| %>
+<meta property="<%= property %>" content="<%= content %>" />
+<% end %>
+
+<% config.meta_names.each do |name, content| %>
+<meta name="<%= name %>" content="<%= content %>" />
+<% end %>
+
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 

--- a/files/reveal-ck/templates/index.html/index.html.erb
+++ b/files/reveal-ck/templates/index.html/index.html.erb
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="en">
-  <head>
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
     <%= head %>
   </head>
 

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -27,15 +27,9 @@ module RevealCK
         'author'      => '',
         'theme'       => 'black',
         'transition'  => 'default',
-        'data' => {
-
-        },
-        'meta_properties' => {
-
-        },
-        'meta_names' => {
-
-        }
+        'data' => {},
+        'meta_properties' => {},
+        'meta_names' => {}
       }
     end
 

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -29,6 +29,12 @@ module RevealCK
         'transition'  => 'default',
         'data' => {
 
+        },
+        'meta_properties' => {
+
+        },
+        'meta_names' => {
+
         }
       }
     end

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'relish'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '0.46.0'
   s.add_development_dependency 'simplecov'
 
   files = {


### PR DESCRIPTION
# Overview
Supports OGP meta tag contents (e.g. `<meta property="og:title" >`)

## Details
I want to share URL of slide generated with `reveal-ck` to twitter or facebook, but content is very cheep :persevere:

This PR supports arbitrary embed meta tag.

# Example
## Before
### Twitter
![before-tw](https://cloud.githubusercontent.com/assets/608755/25071594/671ac91c-22f6-11e7-826f-8d4ce8bf51e2.png)

### Facebook
![before-fb](https://cloud.githubusercontent.com/assets/608755/25071596/6e7b22c4-22f6-11e7-98ca-a082e40d7d37.png)

## After
https://sue445.github.io/reveal-ck-example/#/

### [config.yml](https://github.com/sue445/reveal-ck-example/blob/05425cbdd2afac46457c6d943c2b3b50777f5f39/config.yml)

```yaml
meta_properties:
  og:type: "website"
  og:title: "Example slide"
  og:description: "Example slide"
  og:url: "https://sue445.github.io/reveal-ck-example/#/"
  og:image: "https://sue445.github.io/reveal-ck-example/images/github_unicorn.png"

meta_names:
  twitter:card: "summary"
  twitter:site: "@sue445"
  twitter:creator: "@sue445"
  twitter:title: "Example slide"
  twitter:description: "Example slide"
  twitter:image: "https://sue445.github.io/reveal-ck-example/images/github_unicorn.png"
```

### Twitter
![after-tw](https://cloud.githubusercontent.com/assets/608755/25071597/72915022-22f6-11e7-9736-02d80a0612a2.png)

### Facebook
![after-fb](https://cloud.githubusercontent.com/assets/608755/25071599/7cd30274-22f6-11e7-8d76-2315092e9ba7.png)
