### PR TITLE
Supporting meta names and properties

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,13 @@ Encoding:
 
 FileName:
   Exclude:
+    - Gemfile
+    - reveal-ck.gemspec
     - lib/reveal-ck.rb
+    - files/reveal-ck/Guardfile
 
 Metrics/BlockLength:
   Exclude:
     - bin/reveal-ck
+    - reveal-ck.gemspec
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,8 @@ Metrics/BlockLength:
     - bin/reveal-ck
     - reveal-ck.gemspec
     - spec/**/*.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - lib/reveal-ck/config.rb
+    - lib/reveal-ck/builders/create_index_html.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,15 @@ bugs are fixed.
 
 ### Added
 
-* Nothing
+* By default, the <head prefix="XYZ"/> value now supports
+  http://ogp.me/. This is configurable.
+
+  Additionally, it is now possible to supply <meta>s with properties
+  and names by putting entries into the config.yml.
+
+  Big thanks to @sue445 without which this wouldn't have happened.
+
+  See https://github.com/jedcn/reveal-ck/pull/82 for details.
 
 ### Changed
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,4 @@ end
 
 task default: :ci
 
-task test: [:spec, :cucumber]
+task test: %i[spec cucumber]

--- a/bin/reveal-ck
+++ b/bin/reveal-ck
@@ -14,10 +14,10 @@ class RevealCKExecutable
   command :generate do |c|
     default_file = FileList['slides.*'].first
     c.desc 'The file containing your slide content'
-    c.flag [:f, :file], default_value: default_file
+    c.flag %i[f file], default_value: default_file
 
     c.desc 'The directory for generated slides. Default based on slide file.'
-    c.flag [:d, :dir]
+    c.flag %i[d dir]
 
     c.action do |_, options, _|
       slides_file = options[:file]
@@ -51,16 +51,16 @@ class RevealCKExecutable
   command :serve, :server do |c|
     default_file = FileList['slides.*'].first
     c.desc 'The file containing your slide content'
-    c.flag [:f, :file], default_value: default_file
+    c.flag %i[f file], default_value: default_file
 
     c.desc 'The directory to serve up. Default is based on slide file.'
-    c.flag [:d, :dir]
+    c.flag %i[d dir]
 
     c.desc 'The port to serve on'
-    c.flag [:p, :port], default_value: 10_000
+    c.flag %i[p port], default_value: 10_000
 
     c.desc 'The host to serve on'
-    c.flag [:h, :host], default_value: 'localhost'
+    c.flag %i[h host], default_value: 'localhost'
 
     c.desc 'Exit after starting + n seconds (for testing only)'
     c.flag ['test-quit-after-starting'], type: Integer

--- a/examples/programmatic_slides.rb
+++ b/examples/programmatic_slides.rb
@@ -1,4 +1,5 @@
 require_relative '../lib/reveal-ck'
+require 'active_support/core_ext/string/strip'
 
 intro_slide =
   RevealCK::Slide.new(
@@ -9,11 +10,11 @@ intro_slide =
     link:     'http://hakim.se',
     twitter:  'hakimel'
   )
-quote_content = <<eos
-For years there has been a theory that millions of monkeys typing at
-random on millions of typewriters would reproduce the entire works of
-Shakespeare. The Internet has proven this theory to be untrue.
-eos
+quote_content = <<-EOS.strip_heredoc
+              For years there has been a theory that millions of monkeys typing at
+              random on millions of typewriters would reproduce the entire works of
+              Shakespeare. The Internet has proven this theory to be untrue.
+              EOS
 
 quote_slide =
   RevealCK::Slide.new(
@@ -33,19 +34,19 @@ image_slide =
     height:   '299'
   )
 
-sample_code = <<eos
-function linkify( selector ) {
-  if( supports3DTransforms ) {
-    var nodes = document.querySelectorAll( selector );
-    for( var i = 0, len = nodes.length; i &lt; len; i++ ) {
-      var node = nodes[i];
-      if( !node.className ) {
-        node.className += ' roll';
-      }
-    }
-  }
-}
-eos
+sample_code = <<-EOS.strip_heredoc
+            function linkify( selector ) {
+              if( supports3DTransforms ) {
+                  var nodes = document.querySelectorAll( selector );
+                  for( var i = 0, len = nodes.length; i &lt; len; i++ ) {
+                    var node = nodes[i];
+                    if( !node.className ) {
+                      node.className += ' roll';
+                    }
+                  }
+                }
+              }
+            EOS
 
 code_slide =
   RevealCK::Slide.new(

--- a/features/generate-with-config.feature
+++ b/features/generate-with-config.feature
@@ -171,6 +171,24 @@ Feature: The capabilities of config.yml
     And the file "slides/index.html" should have html matching the css:
     | img[src*="reveal-js/reveal-parallax-1.jpg"]  | the referenced image |
 
+  Scenario: Generating slides and specifying head_prefix
+    Given a file named "config.yml" with:
+    """
+    head_prefix: 'og: http://ogp.me/ns#'
+    """
+    Given a file named "slides.md" with:
+    """
+    # Hello World
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the following files should exist:
+      | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <head prefix="og: http://ogp.me/ns#">
+    """
+
   Scenario: Generating slides with a template and og configs
     Given a file named "config.yml" with:
     """
@@ -191,6 +209,10 @@ Feature: The capabilities of config.yml
     And the file "slides/index.html" should contain:
     """
     <meta property="og:title" content="reveal-ck" />
+    """
+    And the file "slides/index.html" should contain:
+    """
+    <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
     """
 
   Scenario: Generating slides with a template and twitter configs

--- a/features/generate-with-config.feature
+++ b/features/generate-with-config.feature
@@ -170,3 +170,47 @@ Feature: The capabilities of config.yml
     | slides/index.html  |
     And the file "slides/index.html" should have html matching the css:
     | img[src*="reveal-js/reveal-parallax-1.jpg"]  | the referenced image |
+
+  Scenario: Generating slides with a template and og configs
+    Given a file named "config.yml" with:
+    """
+    meta_properties:
+      og:title: "reveal-ck"
+    """
+    Given a file named "slides.haml" with:
+    """
+    %section
+      %p
+        Config
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.haml'..\n"
+    And the following files should exist:
+      | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <meta property="og:title" content="reveal-ck" />
+    """
+
+  Scenario: Generating slides with a template and twitter configs
+    Given a file named "config.yml" with:
+    """
+    meta_names:
+      twitter:title: "reveal-ck"
+    """
+    Given a file named "slides.haml" with:
+    """
+    %section
+      %p
+        Config
+    """
+    When I run `reveal-ck generate`
+    Then the exit status should be 0
+    And the output should contain exactly "Generating slides for 'slides.haml'..\n"
+    And the following files should exist:
+      | slides/index.html  |
+    And the file "slides/index.html" should contain:
+    """
+    <meta name="twitter:title" content="reveal-ck" />
+    """

--- a/files/reveal-ck/Guardfile
+++ b/files/reveal-ck/Guardfile
@@ -1,5 +1,5 @@
 notification :off
 
 guard 'livereload' do
-  watch(/^slides\/index.html$/)
+  watch(%r{^slides/index.html$})
 end

--- a/files/reveal-ck/templates/index.html/head.html.erb
+++ b/files/reveal-ck/templates/index.html/head.html.erb
@@ -6,6 +6,14 @@
 <meta name="author" content="<%= config.author %>">
 <meta name="generator" content="reveal-ck <%= RevealCK::VERSION %>">
 
+<% config.meta_properties.each do |property, content| %>
+<meta property="<%= property %>" content="<%= content %>" />
+<% end %>
+
+<% config.meta_names.each do |name, content| %>
+<meta name="<%= name %>" content="<%= content %>" />
+<% end %>
+
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 

--- a/files/reveal-ck/templates/index.html/index.html.erb
+++ b/files/reveal-ck/templates/index.html/index.html.erb
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="en">
-  <head>
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
     <%= head %>
   </head>
 

--- a/files/reveal-ck/templates/index.html/index.html.erb
+++ b/files/reveal-ck/templates/index.html/index.html.erb
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="en">
-  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+  <head prefix="<%= head_prefix %>">
     <%= head %>
   </head>
 

--- a/lib/reveal-ck/builders/create_index_html.rb
+++ b/lib/reveal-ck/builders/create_index_html.rb
@@ -21,6 +21,7 @@ module RevealCK
         index_html_file = "#{output_dir}/index.html"
         task(index_html_file => slides_html) do
           content = IndexHtml.new(slides_html: slides_html,
+                                  head_prefix: config.head_prefix,
                                   template: template,
                                   config: config).render
           File.open(index_html_file, 'w') do |index_html|

--- a/lib/reveal-ck/builders/index_html.rb
+++ b/lib/reveal-ck/builders/index_html.rb
@@ -9,11 +9,12 @@ module RevealCK
     class IndexHtml
       include Retrieve
 
-      attr_reader :template, :slides_html, :config
+      attr_reader :template, :slides_html, :head_prefix, :config
 
       def initialize(args)
         @template = retrieve(:template, args)
         @slides_html = retrieve(:slides_html, args)
+        @head_prefix = retrieve(:head_prefix, args)
         @config = retrieve(:config, args)
       end
 
@@ -21,7 +22,8 @@ module RevealCK
         scope = RevealCK::Render::Scope.new(dir: Dir.pwd, config: config)
         tilt_template = Tilt.new(template)
         locals = {
-          slides_html: slides_html
+          slides_html: slides_html,
+          head_prefix: head_prefix
         }
         tilt_template.render(scope, locals)
       end

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -27,15 +27,9 @@ module RevealCK
         'author'      => '',
         'theme'       => 'black',
         'transition'  => 'default',
-        'data' => {
-
-        },
-        'meta_properties' => {
-
-        },
-        'meta_names' => {
-
-        }
+        'data' => {},
+        'meta_properties' => {},
+        'meta_names' => {}
       }
     end
 

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -20,16 +20,22 @@ module RevealCK
        filter_defaults].reduce({}) { |acc, elem| acc.merge(elem) }
     end
 
+    OPEN_GRAPH_PREFIX =
+      'og: http://ogp.me/ns# ' \
+      'fb: http://ogp.me/ns/fb# ' \
+      'article: http://ogp.me/ns/article#'.freeze
+
     def core_defaults
       {
-        'title'       => 'Slides',
-        'description' => '',
-        'author'      => '',
-        'theme'       => 'black',
-        'transition'  => 'default',
-        'data' => {},
+        'title'           => 'Slides',
+        'description'     => '',
+        'author'          => '',
+        'theme'           => 'black',
+        'transition'      => 'default',
+        'data'            => {},
         'meta_properties' => {},
-        'meta_names' => {}
+        'meta_names'      => {},
+        'head_prefix'     => OPEN_GRAPH_PREFIX
       }
     end
 

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -29,6 +29,12 @@ module RevealCK
         'transition'  => 'default',
         'data' => {
 
+        },
+        'meta_properties' => {
+
+        },
+        'meta_names' => {
+
         }
       }
     end

--- a/lib/reveal-ck/presentation.rb
+++ b/lib/reveal-ck/presentation.rb
@@ -8,7 +8,7 @@ module RevealCK
   class Presentation
     include Retrieve
     extend Forwardable
-    [:author, :title, :transition, :theme].each do |name|
+    %i[author title transition theme].each do |name|
       def_delegators :@config, name, "#{name}=".to_sym
     end
 

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -1,2 +1,2 @@
 desc 'Run Continuous Integration'
-task ci: [:spec, :rubocop, :cucumber]
+task ci: %i[spec rubocop cucumber]

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'relish'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '0.46.0'
   s.add_development_dependency 'simplecov'
 
   files = {

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
-require File.join([File.dirname(__FILE__),'lib','reveal-ck','version.rb'])
+
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+require File.join([File.dirname(__FILE__), 'lib', 'reveal-ck', 'version.rb'])
 
 Gem::Specification.new do |s|
   s.date = '2017-01-14'
@@ -13,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/jedcn/reveal-ck'
   s.summary     = 'Create reveal.js presentations with Markdown.'
   s.description =
-    'A command line interface for generating reveal.js presentations from markdown.'
+    'A cli for generating reveal.js presentations from markdown.'
   #
   # Runtime Dependencies
   s.add_dependency 'docile', '1.1.5'
@@ -35,23 +36,25 @@ Gem::Specification.new do |s|
 
   #
   # Development Dependencies
+  s.add_development_dependency 'activesupport'
   s.add_development_dependency 'aruba'
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'relish'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop', '0.46.0'
+  s.add_development_dependency 'rubocop'
   s.add_development_dependency 'simplecov'
 
   files = {
-    core: ['LICENSE', 'Rakefile', 'Gemfile'],
+    core: %w[LICENSE Rakefile Gemfile],
     supporting: Dir.glob('files/**/*'),
     lib: `git ls-files lib`.split("\n"),
     rakelib: `git ls-files rakelib`.split("\n")
   }
 
-  s.files         = files[:core] + files[:lib] + files[:rakelib] + files[:supporting]
+  s.files         = files[:core] + files[:lib] + files[:rakelib] +
+                    files[:supporting]
   s.test_files    = `git ls-files -- {spec,features}/**/*`.split("\n")
   s.executables   = ['reveal-ck']
   s.require_paths = ['lib']

--- a/spec/lib/reveal-ck/builders/create_slides_html_spec.rb
+++ b/spec/lib/reveal-ck/builders/create_slides_html_spec.rb
@@ -64,7 +64,7 @@ module RevealCK
             end
 
             config = Config.new
-            config.requires = %w(json time)
+            config.requires = %w[json time]
             application = Rake::Application.new
             slides_html =
               CreateSlidesHtml.new(slides_file: slides_file_initial,

--- a/spec/lib/reveal-ck/builders/creation_task_spec.rb
+++ b/spec/lib/reveal-ck/builders/creation_task_spec.rb
@@ -55,7 +55,7 @@ module RevealCK
 
           it 'defines a task on the application' do
             args_expected_to_be_passed_to_rake = {
-              'creation_task_testing_class' => %w(foo bar)
+              'creation_task_testing_class' => %w[foo bar]
             }
             application = double
             expect(application)

--- a/spec/lib/reveal-ck/builders/index_html_spec.rb
+++ b/spec/lib/reveal-ck/builders/index_html_spec.rb
@@ -13,6 +13,10 @@ module RevealCK
         spec_data('builders', 'index_html', 'slides.html')
       end
 
+      let :head_prefix do
+        'head_prefix'
+      end
+
       let :config do
         config = Config.new
         config.title = 'Sample Title'
@@ -26,6 +30,7 @@ module RevealCK
       let :index_html do
         IndexHtml.new(template: index_html_erb,
                       slides_html: slides_html,
+                      head_prefix: head_prefix,
                       config: config)
       end
 
@@ -41,6 +46,11 @@ module RevealCK
       it 'can render html' do
         expect(rendered_content)
           .to include('<html lang="en">')
+      end
+
+      it 'can render a <head with a prefix' do
+        expect(rendered_content)
+          .to include('<head prefix="head_prefix">')
       end
 
       it 'prints the program name and version in the generator tag' do

--- a/spec/lib/reveal-ck/config_spec.rb
+++ b/spec/lib/reveal-ck/config_spec.rb
@@ -57,6 +57,11 @@ module RevealCK
           .to eq 'https://assets-cdn.github.com/images/icons/'
       end
 
+      it 'supplies a default head_prefix' do
+        expect(config.head_prefix)
+          .to eq 'og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#'
+      end
+
       it 'supplies a default list of filters' do
         expect(config.filters).to eq ['HTML::Pipeline::RevealCKEmojiFilter',
                                       'HTML::Pipeline::MentionFilter',

--- a/spec/lib/reveal-ck/markdown/post_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/post_processor_spec.rb
@@ -19,19 +19,19 @@ module RevealCK
 
       context 'handling notes' do
         let :transformed_notes do
-          <<-eos
-<div>DIVIDER</div>
+          <<-EOS.strip_heredoc
+          <div>DIVIDER</div>
 
 
-<div>NOTES_OPEN</div>
+          <div>NOTES_OPEN</div>
 
-This is a note
+          This is a note
 
-<div>NOTES_CLOSE</div>
+          <div>NOTES_CLOSE</div>
 
 
-<div>DIVIDER</div>
-eos
+          <div>DIVIDER</div>
+          EOS
         end
 
         it 'translates <div>NOTES_OPEN</div> into <aside class="notes">' do
@@ -47,41 +47,41 @@ eos
 
       context 'without vertical slides' do
         let :three_slide_input do
-          <<-eos
-<div>DIVIDER</div>
+          <<-EOS.strip_heredoc
+          <div>DIVIDER</div>
 
-<p>First</p>
+          <p>First</p>
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-<p>Second</p>
+          <p>Second</p>
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-<p>Third</p>
+          <p>Third</p>
 
-<div>DIVIDER</div>
-eos
+          <div>DIVIDER</div>
+          EOS
         end
 
         let :three_slides_output do
-          <<-eos
-<section>
+          <<-EOS.strip_heredoc
+          <section>
 
-<p>First</p>
+          <p>First</p>
 
-</section>
-<section>
+          </section>
+          <section>
 
-<p>Second</p>
+          <p>Second</p>
 
-</section>
-<section>
+          </section>
+          <section>
 
-<p>Third</p>
+          <p>Third</p>
 
-</section>
-eos
+          </section>
+          EOS
         end
 
         it 'starts the output with a <section> and a newline' do
@@ -103,43 +103,43 @@ eos
       context 'with vertical slides' do
         context 'single vertical slide' do
           let :single_vertical_input do
-            <<-eos
-<div>VERTICAL_START</div>
+            <<-EOS.strip_heredoc
+            <div>VERTICAL_START</div>
 
-First
+            First
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Second
+            Second
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Third
+            Third
 
-<div>VERTICAL_END</div>
-eos
+            <div>VERTICAL_END</div>
+            EOS
           end
 
           let :single_vertical_output do
-            <<-eos
-<section>
-<section>
+            <<-EOS.strip_heredoc
+            <section>
+            <section>
 
-First
+            First
 
-</section>
-<section>
+            </section>
+            <section>
 
-Second
+            Second
 
-</section>
-<section>
+            </section>
+            <section>
 
-Third
+            Third
 
-</section>
-</section>
-eos
+            </section>
+            </section>
+            EOS
           end
 
           it 'starts the output with two <section>s' do
@@ -160,76 +160,76 @@ eos
 
         context 'back-to-back vertical slides' do
           let :double_vertical_input do
-            <<-eos
-<div>VERTICAL_START</div>
+            <<-EOS.strip_heredoc
+            <div>VERTICAL_START</div>
 
-Vertical A1
+            Vertical A1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A2
+            Vertical A2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A3
+            Vertical A3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical B1
+            Vertical B1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B2
+            Vertical B2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B3
+            Vertical B3
 
-<div>VERTICAL_END</div>
-eos
+            <div>VERTICAL_END</div>
+            EOS
           end
 
           let :double_vertical_output do
-            <<-eos
-<section>
-<section>
+            <<-EOS.strip_heredoc
+            <section>
+            <section>
 
-Vertical A1
+            Vertical A1
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical A2
+            Vertical A2
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical A3
+            Vertical A3
 
-</section>
-</section>
+            </section>
+            </section>
 
-<section>
-<section>
+            <section>
+            <section>
 
-Vertical B1
+            Vertical B1
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical B2
+            Vertical B2
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical B3
+            Vertical B3
 
-</section>
-</section>
-eos
+            </section>
+            </section>
+            EOS
           end
 
           it 'creates two columns of sections' do
@@ -240,99 +240,99 @@ eos
 
         context 'horizontal and vertical combinations' do
           let :verticals_surrounded_by_horizontals_input do
-            <<-eos
-<div>DIVIDER</div>
+            <<-EOS.strip_heredoc
+            <div>DIVIDER</div>
 
-First
+            First
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical A1
+            Vertical A1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A2
+            Vertical A2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A3
+            Vertical A3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Middle
+            Middle
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical B1
+            Vertical B1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B2
+            Vertical B2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B3
+            Vertical B3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Last
+            Last
 
-<div>DIVIDER</div>
-eos
+            <div>DIVIDER</div>
+            EOS
           end
 
           let :verticals_surrounded_by_horizontals_output do
-            <<-eos
-<section>
+            <<-EOS.strip_heredoc
+            <section>
 
-First
+            First
 
-</section>
-<section>
-<section>
+            </section>
+            <section>
+            <section>
 
-Vertical A1
+            Vertical A1
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical A2
+            Vertical A2
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical A3
+            Vertical A3
 
-</section>
-</section>
-<section>
+            </section>
+            </section>
+            <section>
 
-Middle
+            Middle
 
-</section>
-<section>
-<section>
+            </section>
+            <section>
+            <section>
 
-Vertical B1
+            Vertical B1
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical B2
+            Vertical B2
 
-</section>
-<section>
+            </section>
+            <section>
 
-Vertical B3
+            Vertical B3
 
-</section>
-</section>
-<section>
+            </section>
+            </section>
+            <section>
 
-Last
+            Last
 
-</section>
-eos
+            </section>
+            EOS
           end
 
           it 'creates a slide, a column, a slide, a column, and a slide' do

--- a/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
@@ -5,35 +5,35 @@ module RevealCK
     describe PreProcessor do
       describe 'handling ```notes' do
         let :notes_input do
-          <<-eos
-```notes
-This is a note
-```
-eos
+          <<-EOS.strip_heredoc
+          ```notes
+          This is a note
+          ```
+          EOS
         end
 
         let :note_input do
-          <<-eos
-```note
-This is a note
-```
-eos
+          <<-EOS.strip_heredoc
+          ```note
+          This is a note
+          ```
+          EOS
         end
 
         let :transformed_notes do
-          <<-eos
-<div>DIVIDER</div>
+          <<-EOS.strip_heredoc
+          <div>DIVIDER</div>
 
 
-<div>NOTES_OPEN</div>
+          <div>NOTES_OPEN</div>
 
-This is a note
+          This is a note
 
-<div>NOTES_CLOSE</div>
+          <div>NOTES_CLOSE</div>
 
 
-<div>DIVIDER</div>
-eos
+          <div>DIVIDER</div>
+          EOS
         end
 
         it 'transforms ```notes into <div>NOTES_OPEN</div>' do
@@ -72,13 +72,13 @@ eos
       end
 
       let :standard_result do
-        <<-eos
-<div>DIVIDER</div>
+        <<-EOS.strip_heredoc
+        <div>DIVIDER</div>
 
-First
+        First
 
-<div>DIVIDER</div>
-eos
+        <div>DIVIDER</div>
+        EOS
       end
 
       context 'without vertical slides' do
@@ -89,59 +89,59 @@ eos
         end
 
         it 'is consistent when starting+ending separators are used' do
-          input =  <<-eos
----
-First
----
-eos
+          input = <<-EOS.strip_heredoc
+          ---
+          First
+          ---
+          EOS
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         it 'is consistent when only starting separators are used' do
-          input = <<-eos
----
-First
-eos
+          input = <<-EOS.strip_heredoc
+          ---
+          First
+          EOS
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         it 'is consistent when only ending separators are used' do
-          input = <<-eos
-First
----
-eos
+          input = <<-EOS.strip_heredoc
+          First
+          ---
+          EOS
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         let :three_slides_input do
-          <<-eos
-First
----
-Second
----
-Third
-eos
+          <<-EOS.strip_heredoc
+          First
+          ---
+          Second
+          ---
+          Third
+          EOS
         end
 
         let :three_slides_output do
-          <<-eos
-<div>DIVIDER</div>
+          <<-EOS.strip_heredoc
+          <div>DIVIDER</div>
 
-First
+          First
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-Second
+          Second
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-Third
+          Third
 
-<div>DIVIDER</div>
-eos
+          <div>DIVIDER</div>
+          EOS
         end
 
         it 'can handle three slides' do
@@ -153,47 +153,47 @@ eos
 
       context 'with vertical slides' do
         let :single_vertical_output do
-          <<-eos
-<div>VERTICAL_START</div>
+          <<-EOS.strip_heredoc
+          <div>VERTICAL_START</div>
 
-First
+          First
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-Second
+          Second
 
-<div>DIVIDER</div>
+          <div>DIVIDER</div>
 
-Third
+          Third
 
-<div>VERTICAL_END</div>
-eos
+          <div>VERTICAL_END</div>
+          EOS
         end
 
         context 'single vertical slide' do
           it 'handles situation with no "closing" vertical' do
-            unbalanced_vertical_markdown = <<-eos
-***
-First
----
-Second
----
-Third
-eos
+            unbalanced_vertical_markdown = <<-EOS.strip_heredoc
+            ***
+            First
+            ---
+            Second
+            ---
+            Third
+            EOS
             output = PreProcessor.new(unbalanced_vertical_markdown).process
             expect(output).to eq single_vertical_output
           end
 
           it 'handles situation with a "closing" vertical' do
-            balanced_vertical_markdown = <<-eos
-***
-First
----
-Second
----
-Third
-***
-eos
+            balanced_vertical_markdown = <<-EOS.strip_heredoc
+            ***
+            First
+            ---
+            Second
+            ---
+            Third
+            ***
+            EOS
 
             output = PreProcessor.new(balanced_vertical_markdown).process
             expect(output).to eq single_vertical_output
@@ -202,163 +202,163 @@ eos
 
         context 'horizontal and vertical combinations' do
           it 'handles vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-eos
-First
-***
-Vertical 1
----
-Vertical 2
----
-Vertical 3
-***
-Last
-eos
+            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            First
+            ***
+            Vertical 1
+            ---
+            Vertical 2
+            ---
+            Vertical 3
+            ***
+            Last
+            EOS
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-eos
-<div>DIVIDER</div>
+            expect(output).to eq <<-EOS.strip_heredoc
+            <div>DIVIDER</div>
 
-First
+            First
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical 1
+            Vertical 1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical 2
+            Vertical 2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical 3
+            Vertical 3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Last
+            Last
 
-<div>DIVIDER</div>
-eos
+            <div>DIVIDER</div>
+            EOS
           end
 
           it 'handles back-to-back vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-eos
-First
-***
-Vertical A1
----
-Vertical A2
----
-Vertical A3
-***
-***
-Vertical B1
----
-Vertical B2
----
-Vertical B3
-***
-Last
-eos
+            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            First
+            ***
+            Vertical A1
+            ---
+            Vertical A2
+            ---
+            Vertical A3
+            ***
+            ***
+            Vertical B1
+            ---
+            Vertical B2
+            ---
+            Vertical B3
+            ***
+            Last
+            EOS
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-eos
-<div>DIVIDER</div>
+            expect(output).to eq <<-EOS.strip_heredoc
+            <div>DIVIDER</div>
 
-First
+            First
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical A1
+            Vertical A1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A2
+            Vertical A2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A3
+            Vertical A3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical B1
+            Vertical B1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B2
+            Vertical B2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B3
+            Vertical B3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Last
+            Last
 
-<div>DIVIDER</div>
-eos
+            <div>DIVIDER</div>
+            EOS
           end
 
           it 'handles multiple vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-eos
-First
-***
-Vertical A1
----
-Vertical A2
----
-Vertical A3
-***
-Middle
-***
-Vertical B1
----
-Vertical B2
----
-Vertical B3
-***
-Last
-eos
+            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            First
+            ***
+            Vertical A1
+            ---
+            Vertical A2
+            ---
+            Vertical A3
+            ***
+            Middle
+            ***
+            Vertical B1
+            ---
+            Vertical B2
+            ---
+            Vertical B3
+            ***
+            Last
+            EOS
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-eos
-<div>DIVIDER</div>
+            expect(output).to eq <<-EOS.strip_heredoc
+            <div>DIVIDER</div>
 
-First
+            First
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical A1
+            Vertical A1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A2
+            Vertical A2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical A3
+            Vertical A3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Middle
+            Middle
 
-<div>VERTICAL_START</div>
+            <div>VERTICAL_START</div>
 
-Vertical B1
+            Vertical B1
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B2
+            Vertical B2
 
-<div>DIVIDER</div>
+            <div>DIVIDER</div>
 
-Vertical B3
+            Vertical B3
 
-<div>VERTICAL_END</div>
+            <div>VERTICAL_END</div>
 
-Last
+            Last
 
-<div>DIVIDER</div>
-eos
+            <div>DIVIDER</div>
+            EOS
           end
         end
       end

--- a/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
+++ b/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
@@ -14,71 +14,71 @@ module RevealCK
       end
 
       it 'does not turn _s within a single emoji into <em>s' do
-        output = render_markdown <<-eos
-:money_with_wings:
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        :money_with_wings:
+        EOS
         expect(output).to include ':money_with_wings:'
       end
 
       it 'does not turn _s between two emojis into <em>s' do
-        output = render_markdown <<-eos
-:blue_heart: :blue_heart:
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        :blue_heart: :blue_heart:
+        EOS
         expect(output).to include ':blue_heart: :blue_heart:'
       end
 
       it 'uses "---" to create "<section>"s' do
-        output = render_markdown <<-eos
-# h1 Slide
----
-## h2 Slide
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        # h1 Slide
+        ---
+        ## h2 Slide
+        EOS
         expect(output).to include '<h1>h1 Slide</h1>'
         expect(output).to include "</section>\n<section>"
         expect(output).to include '<h2>h2 Slide</h2>'
       end
 
       it 'wraps ``` code in a <pre> and <code>' do
-        output = render_markdown <<-eos
-```
-def adder(a, b); a + b; end
-```
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        ```
+        def adder(a, b); a + b; end
+        ```
+        EOS
         expect(output).to include '<pre><code>'
         expect(output).to include '</code></pre>'
         expect(output).to include 'a + b'
       end
 
       it 'converts special characters in ``` block to entity references' do
-        output = render_markdown <<-eos
-```
-<p>"&"</p>
-```
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        ```
+        <p>"&"</p>
+        ```
+        EOS
         expect(output).to include '<pre><code>'
         expect(output).to include '</code></pre>'
         expect(output).to include '&lt;p&gt;"&amp;"&lt;/p&gt;'
       end
 
       it 'wraps ```ruby code in a <pre> and <code class="language-ruby">' do
-        output = render_markdown <<-eos
-```ruby
-def adder(a, b); a + b; end
-```
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        ```ruby
+        def adder(a, b); a + b; end
+        ```
+        EOS
         expect(output).to include '<pre><code class="language-ruby">'
         expect(output).to include '</code></pre>'
         expect(output).to include 'a + b'
       end
 
       it 'works when there is no space surrounding the ---' do
-        output = render_markdown <<-eos
-# Your headline
-* Bullet 1
-* Bullet 2
----
-# Next Slide
-eos
+        output = render_markdown <<-EOS.strip_heredoc
+        # Your headline
+        * Bullet 1
+        * Bullet 2
+        ---
+        # Next Slide
+        EOS
         expect(output).to include "</section>\n<section>"
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'simplecov'
 require 'codeclimate-test-reporter'
+require 'active_support/core_ext/string/strip'
+
 SimpleCov.start
 
 # silence tilt autoload warnings


### PR DESCRIPTION
# Overview

This change builds off of #82.

In addition to the work there it:

* Does some house keeping around rubocop and `CHANGELOG.md`.
* Makes the `<head prefix=""/>` configurable

However, the value of `<head prefix=""/>` defaults to what's needed to support http://ogp.me/.

## Details

I'm opening this PR to provide transparency to @sue445.

The changes in #82 will be active once this comes in.

Thanks for your contribution!