### PR TITLE
Update reveal.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ bugs are fixed.
 
 ### Changed
 
-* Nothing
+* The embedded version of reveal.js has been updated to version 3.5.0. See
+  https://github.com/hakimel/reveal.js/releases/tag/3.5.0 for details.
 
 ### Fixed
 


### PR DESCRIPTION
# Overview

This change updates reveal.js to version 3.5.0.

It's been opened in response to #84.

## Details

I haven't done much testing, but I have seen the feature that @rastamhadi was interested in.