### PR TITLE
dynamic js dependencies

### DIFF
--- a/files/reveal-ck/templates/index.html/script.js.erb
+++ b/files/reveal-ck/templates/index.html/script.js.erb
@@ -16,6 +16,10 @@
       { src: 'plugin/notes/notes.js', async: true }
     ]
   };
+  <% config.js_dependencies.each do |js_dep| %>
+    baseOptions.dependencies.push(<%= js_dep.to_json %>);
+  <% end %>
+
   var configOptions = <%= config.revealjs_config.to_json %>
   var initializeOptions = {};
   extend(initializeOptions, baseOptions);

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -35,6 +35,7 @@ module RevealCK
         'data'            => {},
         'meta_properties' => {},
         'meta_names'      => {},
+        'js_dependencies' => [],
         'head_prefix'     => OPEN_GRAPH_PREFIX
       }
     end


### PR DESCRIPTION
# Overview

Allow the config to support a list of dynamic dependencies for the js dependencies (needed to use plugins)

## Details

No testing done yet. If this is a feature that you'd like to see, I'm happy to add some tests. It looks like adding plugins into the presentation is already supported, but I didn't see a way to include them in the js context.

Example config
```yaml
title:      "some presentation"
author:     "Jay OConnor"
theme:      "sky"
js_dependencies:
  - src: 'plugin/mermaid/mermaid.js'
```