### PR TITLE
Support Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ bugs are fixed.
 
 ### Added
 
-* Nothing
+* Any file ending in *.js in the js/ directory will now be added as a <script>
+  tag.
+* Any file ending in *.js in the plugin/ directory will now be configured to be a reveal.js plugin.
+* Putting these two items together: reveal-ck now supports reveal.js plugins.
 
 ### Changed
 

--- a/features/generate-with-js-plugin.feature
+++ b/features/generate-with-js-plugin.feature
@@ -7,14 +7,24 @@ Feature: How to store and reference a js plugin
     Given a file named "slides.md" with:
     """
     # Slides
+
+    ---
+
+    # They Change
     """
-    And a file named "plugin/sample/sample.js" with:
+    And a file named "plugin/changed/changed.js" with:
     """
-    (function() {
-      alert('Hi');
-    })();
+    (function(){
+      Reveal.addEventListener('slidechanged', function(event) {
+        console.log('slidechanged');
+      });
+    }());
     """
     When I run `reveal-ck generate`
     Then the exit status should be 0
     And the following files should exist:
-    | slides/plugin/sample/sample.js |
+    | slides/plugin/changed/changed.js |
+    And the file "slides/index.html" should contain:
+    """
+    baseOptions.dependencies.push({ src: 'plugin/changed/changed.js', async: true });
+    """

--- a/features/generate-with-js.feature
+++ b/features/generate-with-js.feature
@@ -1,7 +1,7 @@
 Feature: How to store and reference js
 
   Files placed into the `js/` directory will be copied into the
-  presentation.
+  presentation and included in the <head>.
 
   Scenario: Generating slides that contain a js file
     Given a file named "slides.md" with:
@@ -11,10 +11,25 @@ Feature: How to store and reference js
     And a file named "js/custom.js" with:
     """
     (function() {
-      alert('Hi');
+      console.log('Hi from js/custom.js');
+    })();
+    """
+    And a file named "js/nested/custom.js" with:
+    """
+    (function() {
+      console.log('Hi from js/nested/custom.js');
     })();
     """
     When I run `reveal-ck generate`
     Then the exit status should be 0
     And the following files should exist:
     | slides/js/custom.js |
+    | slides/js/nested/custom.js |
+    And the file "slides/index.html" should contain:
+    """
+    <script src="js/custom.js"></script>
+    """
+    And the file "slides/index.html" should contain:
+    """
+    <script src="js/nested/custom.js"></script>
+    """

--- a/files/reveal-ck/templates/index.html/body.html.erb
+++ b/files/reveal-ck/templates/index.html/body.html.erb
@@ -8,6 +8,10 @@
 <script src="lib/js/head.min.js"></script>
 <script src="js/reveal.js"></script>
 
+<% js_files.each do |file| %>
+<script src="<%= file %>"></script>
+<% end %>
+
 <script>
   <%= script %>
 </script>

--- a/files/reveal-ck/templates/index.html/script.js.erb
+++ b/files/reveal-ck/templates/index.html/script.js.erb
@@ -16,8 +16,9 @@
       { src: 'plugin/notes/notes.js', async: true }
     ]
   };
-  <% config.js_dependencies.each do |js_dep| %>
-    baseOptions.dependencies.push(<%= js_dep.to_json %>);
+
+  <% plugin_files.each do |plugin| %>
+    baseOptions.dependencies.push({ src: '<%= plugin %>', async: true });
   <% end %>
 
   var configOptions = <%= config.revealjs_config.to_json %>

--- a/files/reveal-ck/templates/index.html/script.js.erb
+++ b/files/reveal-ck/templates/index.html/script.js.erb
@@ -16,6 +16,10 @@
       { src: 'plugin/notes/notes.js', async: true }
     ]
   };
+  <% config.js_dependencies.each do |js_dep| %>
+    baseOptions.dependencies.push(<%= js_dep.to_json %>);
+  <% end %>
+
   var configOptions = <%= config.revealjs_config.to_json %>
   var initializeOptions = {};
   extend(initializeOptions, baseOptions);

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -35,7 +35,6 @@ module RevealCK
         'data'            => {},
         'meta_properties' => {},
         'meta_names'      => {},
-        'js_dependencies' => [],
         'head_prefix'     => OPEN_GRAPH_PREFIX
       }
     end

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -35,6 +35,7 @@ module RevealCK
         'data'            => {},
         'meta_properties' => {},
         'meta_names'      => {},
+        'js_dependencies' => [],
         'head_prefix'     => OPEN_GRAPH_PREFIX
       }
     end

--- a/lib/reveal-ck/render.rb
+++ b/lib/reveal-ck/render.rb
@@ -1,4 +1,6 @@
 require_relative 'render/contents_of'
 require_relative 'render/css_files'
+require_relative 'render/js_files'
+require_relative 'render/plugin_files'
 require_relative 'render/index_html_maker'
 require_relative 'render/scope'

--- a/lib/reveal-ck/render/js_files.rb
+++ b/lib/reveal-ck/render/js_files.rb
@@ -1,0 +1,15 @@
+module RevealCK
+  module Render
+    # Determine which .js files are underneath a @dir
+    module JsFiles
+      def js_files
+        things_in_js_dir = FileList["#{@dir}/js/**/*"]
+        only_js_files = things_in_js_dir.grep(/\.js$/)
+        relative_js_files = only_js_files.map do |file|
+          file.sub("#{@dir}/", '')
+        end
+        relative_js_files
+      end
+    end
+  end
+end

--- a/lib/reveal-ck/render/plugin_files.rb
+++ b/lib/reveal-ck/render/plugin_files.rb
@@ -1,0 +1,15 @@
+module RevealCK
+  module Render
+    # Determine which js files are in the plugin dir
+    module PluginFiles
+      def plugin_files
+        things_in_plugin_dir = FileList["#{@dir}/plugin/**/*"]
+        only_js_files = things_in_plugin_dir.grep(/\.js$/)
+        relative_plugin_files = only_js_files.map do |file|
+          file.sub("#{@dir}/", '')
+        end
+        relative_plugin_files
+      end
+    end
+  end
+end

--- a/lib/reveal-ck/render/scope.rb
+++ b/lib/reveal-ck/render/scope.rb
@@ -5,6 +5,8 @@ module RevealCK
       include Retrieve
       include ContentsOf
       include CssFiles
+      include JsFiles
+      include PluginFiles
       include IndexHtmlMaker
 
       attr_reader :config


### PR DESCRIPTION
# Overview

## Details

This PR starts with a commit from @jdoconnor.

It then builds on that commit to provide support for using reveal.js plugins.

I don't have much experience with plugins, and this work is based on what it takes to get a mermaid js plugin working.

This is what it does:

1. Presently, files put in the `js/` directory are copied into generated presentations. This PR includes a change that will add these files each into `<script />` tag.
2. Presently, files put in the `plugin/` directory are copied into generated presentations. This PR includes a change that will add the javascript files in the plugin directory to be added as dependencies in `baseOptions.dependencies`.

## Next Steps

* [x] I'll think about missing unit test coverage and the copy/paste that's happening in the files like `css_files.rb`, `js_files.rb`, and `plugin_files.rb`
* [x] I'll squash some commits
* [ ] I'll verify an explicit list of steps for getting mermaid going with the reveal-ck that is published after this PR is merged.
* [ ] I'll do this for haml and experiment to see if I can do it with markdown.