### PR TITLE
Update Rack and Rubocop Tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,9 +9,6 @@ AllCops:
     - tmp/**/*
     - files/reveal.js/**/*
 
-Encoding:
-  EnforcedStyle: when_needed
-
 FileName:
   Exclude:
     - Gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,10 @@ FileName:
     - lib/reveal-ck.rb
     - files/reveal-ck/Guardfile
 
+RescueStandardError:
+  Exclude:
+    - lib/reveal-ck/commands/serve.rb
+
 Metrics/BlockLength:
   Exclude:
     - bin/reveal-ck

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Metrics/MethodLength:
   Exclude:
     - lib/reveal-ck/config.rb
     - lib/reveal-ck/builders/create_index_html.rb
+
+Naming/UncommunicativeMethodParamName:
+  MinNameLength: 1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,12 @@ CyclomaticComplexity:
 
 AllCops:
   Include:
-    - '**/Rakefile'
+    - '**/*.rb'
     - rakelib/*.rake
+    - 'Gemfile'
+    - 'Rakefile'
+    - 'reveal-ck.gemspec'
+    - 'files/reveal-ck/Guardfile'
   Exclude:
     - tmp/**/*
     - files/reveal.js/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ bugs are fixed.
 
 ### Changed
 
-* Nothing
+* Updated the version of rack
+* Minor (shouldn't have a functional impact) tweaks to source
 
 ### Fixed
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ Bundler::GemHelper.install_tasks
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts 'Run `bundle install` to install missing gems'
+  warn e.message
+  warn 'Run `bundle install` to install missing gems'
   exit e.status_code
 end
 

--- a/examples/programmatic_slides.rb
+++ b/examples/programmatic_slides.rb
@@ -4,11 +4,11 @@ require 'active_support/core_ext/string/strip'
 intro_slide =
   RevealCK::Slide.new(
     template: 'intro',
-    title:    'Reveal.js',
+    title: 'Reveal.js',
     subtitle: 'HTML Presentations Made Easy',
-    author:   'Hakim El Hattab',
-    link:     'http://hakim.se',
-    twitter:  'hakimel'
+    author: 'Hakim El Hattab',
+    link: 'http://hakim.se',
+    twitter: 'hakimel'
   )
 quote_content = <<-QUOTE.strip_heredoc
               For years there has been a theory that millions of monkeys typing at
@@ -20,18 +20,18 @@ quote_slide =
   RevealCK::Slide.new(
     template: 'quote',
     headline: 'Clever Quotes',
-    content:  quote_content
+    content: quote_content
   )
 
 meny_png_url = 'http://s3.amazonaws.com/hakim-static/portfolio/images/meny.png'
 image_slide =
   RevealCK::Slide.new(
     template: 'image',
-    src:      meny_png_url,
-    alt:      'Meny',
-    link:     'http://lab.hakim.se/meny/',
-    width:    '320',
-    height:   '299'
+    src: meny_png_url,
+    alt: 'Meny',
+    link: 'http://lab.hakim.se/meny/',
+    width: '320',
+    height: '299'
   )
 
 sample_code = <<-CODE.strip_heredoc
@@ -52,7 +52,7 @@ code_slide =
   RevealCK::Slide.new(
     template: 'code',
     headline: 'Pretty Code',
-    content:  sample_code
+    content: sample_code
   )
 
 p = RevealCK::Presentation.new config: RevealCK::Config.new

--- a/examples/programmatic_slides.rb
+++ b/examples/programmatic_slides.rb
@@ -11,10 +11,10 @@ intro_slide =
     twitter: 'hakimel'
   )
 quote_content = <<-QUOTE.strip_heredoc
-              For years there has been a theory that millions of monkeys typing at
-              random on millions of typewriters would reproduce the entire works of
-              Shakespeare. The Internet has proven this theory to be untrue.
-              QUOTE
+  For years there has been a theory that millions of monkeys typing at
+  random on millions of typewriters would reproduce the entire works of
+  Shakespeare. The Internet has proven this theory to be untrue.
+QUOTE
 
 quote_slide =
   RevealCK::Slide.new(
@@ -35,18 +35,18 @@ image_slide =
   )
 
 sample_code = <<-CODE.strip_heredoc
-            function linkify( selector ) {
-              if( supports3DTransforms ) {
-                  var nodes = document.querySelectorAll( selector );
-                  for( var i = 0, len = nodes.length; i &lt; len; i++ ) {
-                    var node = nodes[i];
-                    if( !node.className ) {
-                      node.className += ' roll';
-                    }
-                  }
-                }
-              }
-            CODE
+  function linkify( selector ) {
+    if( supports3DTransforms ) {
+      var nodes = document.querySelectorAll( selector );
+      for( var i = 0, len = nodes.length; i &lt; len; i++ ) {
+        var node = nodes[i];
+        if( !node.className ) {
+          node.className += ' roll';
+        }
+      }
+    }
+  }
+CODE
 
 code_slide =
   RevealCK::Slide.new(

--- a/examples/programmatic_slides.rb
+++ b/examples/programmatic_slides.rb
@@ -10,11 +10,11 @@ intro_slide =
     link:     'http://hakim.se',
     twitter:  'hakimel'
   )
-quote_content = <<-EOS.strip_heredoc
+quote_content = <<-QUOTE.strip_heredoc
               For years there has been a theory that millions of monkeys typing at
               random on millions of typewriters would reproduce the entire works of
               Shakespeare. The Internet has proven this theory to be untrue.
-              EOS
+              QUOTE
 
 quote_slide =
   RevealCK::Slide.new(
@@ -34,7 +34,7 @@ image_slide =
     height:   '299'
   )
 
-sample_code = <<-EOS.strip_heredoc
+sample_code = <<-CODE.strip_heredoc
             function linkify( selector ) {
               if( supports3DTransforms ) {
                   var nodes = document.querySelectorAll( selector );
@@ -46,7 +46,7 @@ sample_code = <<-EOS.strip_heredoc
                   }
                 }
               }
-            EOS
+            CODE
 
 code_slide =
   RevealCK::Slide.new(

--- a/features/step_definitions/html_match_steps.rb
+++ b/features/step_definitions/html_match_steps.rb
@@ -11,6 +11,7 @@ end
 def check_doc_matches(doc, selector, description, type)
   search_result = doc.send(type, selector)
   return unless search_result.empty?
+
   message = "Could not find #{description}. "
   message += "No match for #{type} '#{selector}'"
   raise message

--- a/features/step_definitions/serve_steps.rb
+++ b/features/step_definitions/serve_steps.rb
@@ -1,5 +1,5 @@
 When(/^I temporarily start reveal\-ck serve with host "(.*?)"$/) do |host|
-  port = 10_000 + rand(1000)
+  port = rand(10_000..11_000)
   cmd = "reveal-ck serve --port #{port} --host #{host}"
   run("#{cmd} --test-quit-after-starting 2")
 end

--- a/lib/reveal-ck/builders/slides_builder.rb
+++ b/lib/reveal-ck/builders/slides_builder.rb
@@ -35,6 +35,7 @@ module RevealCK
       def read_config
         config_file = File.join(user_dir, 'config.yml')
         return unless File.exist?(config_file)
+
         config_as_hash = YAML.load_file config_file
         @config.merge!(config_as_hash)
       end

--- a/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
+++ b/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
@@ -21,6 +21,7 @@ module RevealCK
 
       def message_about_files(files, message)
         return if files.empty?
+
         file_names = files.join(', ')
         ui.message("#{message}: #{file_names}", :rebuild)
       end

--- a/lib/reveal-ck/commands/serve_ui.rb
+++ b/lib/reveal-ck/commands/serve_ui.rb
@@ -7,7 +7,7 @@ module RevealCK
         default: '[ reveal-ck ]',
         problem: '[  problem  ]',
         rebuild: '[  rebuild  ]',
-        reload:  '[   reload  ]'
+        reload: '[   reload  ]'
       }.freeze
 
       def problem(general_problem, specific_error)

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -27,15 +27,15 @@ module RevealCK
 
     def core_defaults
       {
-        'title'           => 'Slides',
-        'description'     => '',
-        'author'          => '',
-        'theme'           => 'black',
-        'transition'      => 'default',
-        'data'            => {},
+        'title' => 'Slides',
+        'description' => '',
+        'author' => '',
+        'theme' => 'black',
+        'transition' => 'default',
+        'data' => {},
         'meta_properties' => {},
-        'meta_names'      => {},
-        'head_prefix'     => OPEN_GRAPH_PREFIX
+        'meta_names' => {},
+        'head_prefix' => OPEN_GRAPH_PREFIX
       }
     end
 

--- a/lib/reveal-ck/markdown/post_processor.rb
+++ b/lib/reveal-ck/markdown/post_processor.rb
@@ -43,12 +43,14 @@ module RevealCK
       def replace_if_start_with(old, new)
         old = "#{old}\n"
         return unless doc.start_with?(old)
+
         @doc = doc[old.size, doc.size - 1]
         @doc = "#{new}\n#{doc}"
       end
 
       def replace_if_end_with(old, new)
         return unless doc.end_with? old
+
         @doc = doc[0, doc.size - 1 - old.size]
         @doc = "#{doc}\n#{new}\n"
       end

--- a/lib/reveal-ck/markdown/pre_processor_for_dividers.rb
+++ b/lib/reveal-ck/markdown/pre_processor_for_dividers.rb
@@ -20,17 +20,20 @@ module RevealCK
       def add_first_slide_divider_if_needed
         return if doc.start_with?(slide_divider)
         return if doc.start_with?(slide_vertical)
+
         prepend(slide_divider)
       end
 
       def add_last_slide_divider_if_needed
         return if doc.end_with?(slide_divider)
         return if doc.end_with?(slide_vertical)
+
         append(slide_divider)
       end
 
       def add_last_slide_vertical_if_needed
         return unless doc.scan(slide_vertical_regex).size.odd?
+
         append(slide_vertical)
       end
 

--- a/lib/reveal-ck/presentation_dsl.rb
+++ b/lib/reveal-ck/presentation_dsl.rb
@@ -5,7 +5,6 @@ module RevealCK
   #
   class PresentationDSL
     include Retrieve
-    attr_reader :author, :title, :theme, :transition
     attr_reader :config
 
     def initialize(args)

--- a/lib/reveal-ck/presentation_dsl.rb
+++ b/lib/reveal-ck/presentation_dsl.rb
@@ -1,4 +1,3 @@
-
 module RevealCK
   #
   # Public: A PresentationDSL defines the DSL behind a

--- a/lib/reveal-ck/rake_task.rb
+++ b/lib/reveal-ck/rake_task.rb
@@ -45,11 +45,11 @@ module RevealCK
       puts "Generating slides for '#{file}'.." if verbose
 
       slides_builder = RevealCK::Builders::SlidesBuilder.new(
-        user_dir:      user_dir,
-        gem_dir:       gem_dir,
-        output_dir:    dir,
-        slides_file:   file,
-        config:        config
+        user_dir: user_dir,
+        gem_dir: gem_dir,
+        output_dir: dir,
+        slides_file: file,
+        config: config
       )
       slides_builder.prepare
       slides_builder.build

--- a/rakelib/prepare_release.rake
+++ b/rakelib/prepare_release.rake
@@ -39,8 +39,8 @@ def update_changelog(old_version, new_version, todays_date)
   add_unreleased_preamble(new_version)
 end
 
-def echo(s)
-  puts "\n#{s}\n"
+def echo(str)
+  puts "\n#{str}\n"
 end
 
 def print_next_steps(new_version)

--- a/rakelib/relish.rake
+++ b/rakelib/relish.rake
@@ -1,4 +1,3 @@
-
 namespace :relish do
   def run(cmd)
     require 'open3'

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'html-pipeline', '2.4.2'
   s.add_dependency 'kramdown', '1.13.1'
   s.add_dependency 'listen', '3.1.5'
-  s.add_dependency 'rack', '2.0.1'
+  s.add_dependency 'rack', '2.0.6'
   s.add_dependency 'rack-livereload', '0.3.16'
   s.add_dependency 'rake', '12.0.0'
   s.add_dependency 'rinku', '2.0.2'

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -1,6 +1,4 @@
-# -*- encoding: utf-8 -*-
-
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require File.join([File.dirname(__FILE__), 'lib', 'reveal-ck', 'version.rb'])
 
 Gem::Specification.new do |s|
@@ -31,8 +29,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake', '12.0.0'
   s.add_dependency 'rinku', '2.0.2'
   s.add_dependency 'slim', '3.0.7'
-  s.add_dependency 'tilt', '2.0.5'
   s.add_dependency 'thor', '0.19.1'
+  s.add_dependency 'tilt', '2.0.5'
 
   #
   # Development Dependencies
@@ -63,5 +61,4 @@ Gem::Specification.new do |s|
     'README.md'
   ]
   s.licenses = ['MIT']
-  s.require_paths = ['lib']
 end

--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'relish'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.60'
   s.add_development_dependency 'simplecov'
 
   files = {

--- a/spec/lib/reveal-ck/markdown/post_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/post_processor_spec.rb
@@ -19,7 +19,7 @@ module RevealCK
 
       context 'handling notes' do
         let :transformed_notes do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <div>DIVIDER</div>
 
 
@@ -31,7 +31,7 @@ module RevealCK
 
 
           <div>DIVIDER</div>
-          EOS
+          HTML
         end
 
         it 'translates <div>NOTES_OPEN</div> into <aside class="notes">' do
@@ -47,7 +47,7 @@ module RevealCK
 
       context 'without vertical slides' do
         let :three_slide_input do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <div>DIVIDER</div>
 
           <p>First</p>
@@ -61,11 +61,11 @@ module RevealCK
           <p>Third</p>
 
           <div>DIVIDER</div>
-          EOS
+          HTML
         end
 
         let :three_slides_output do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <section>
 
           <p>First</p>
@@ -81,7 +81,7 @@ module RevealCK
           <p>Third</p>
 
           </section>
-          EOS
+          HTML
         end
 
         it 'starts the output with a <section> and a newline' do
@@ -103,7 +103,7 @@ module RevealCK
       context 'with vertical slides' do
         context 'single vertical slide' do
           let :single_vertical_input do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <div>VERTICAL_START</div>
 
             First
@@ -117,11 +117,11 @@ module RevealCK
             Third
 
             <div>VERTICAL_END</div>
-            EOS
+            HTML
           end
 
           let :single_vertical_output do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <section>
             <section>
 
@@ -139,7 +139,7 @@ module RevealCK
 
             </section>
             </section>
-            EOS
+            HTML
           end
 
           it 'starts the output with two <section>s' do
@@ -160,7 +160,7 @@ module RevealCK
 
         context 'back-to-back vertical slides' do
           let :double_vertical_input do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <div>VERTICAL_START</div>
 
             Vertical A1
@@ -189,11 +189,11 @@ module RevealCK
             Vertical B3
 
             <div>VERTICAL_END</div>
-            EOS
+            HTML
           end
 
           let :double_vertical_output do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <section>
             <section>
 
@@ -229,7 +229,7 @@ module RevealCK
 
             </section>
             </section>
-            EOS
+            HTML
           end
 
           it 'creates two columns of sections' do
@@ -240,7 +240,7 @@ module RevealCK
 
         context 'horizontal and vertical combinations' do
           let :verticals_surrounded_by_horizontals_input do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <div>DIVIDER</div>
 
             First
@@ -278,11 +278,11 @@ module RevealCK
             Last
 
             <div>DIVIDER</div>
-            EOS
+            HTML
           end
 
           let :verticals_surrounded_by_horizontals_output do
-            <<-EOS.strip_heredoc
+            <<-HTML.strip_heredoc
             <section>
 
             First
@@ -332,7 +332,7 @@ module RevealCK
             Last
 
             </section>
-            EOS
+            HTML
           end
 
           it 'creates a slide, a column, a slide, a column, and a slide' do

--- a/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
+++ b/spec/lib/reveal-ck/markdown/pre_processor_spec.rb
@@ -5,23 +5,23 @@ module RevealCK
     describe PreProcessor do
       describe 'handling ```notes' do
         let :notes_input do
-          <<-EOS.strip_heredoc
+          <<-SLIDES.strip_heredoc
           ```notes
           This is a note
           ```
-          EOS
+          SLIDES
         end
 
         let :note_input do
-          <<-EOS.strip_heredoc
+          <<-SLIDES.strip_heredoc
           ```note
           This is a note
           ```
-          EOS
+          SLIDES
         end
 
         let :transformed_notes do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <div>DIVIDER</div>
 
 
@@ -33,7 +33,7 @@ module RevealCK
 
 
           <div>DIVIDER</div>
-          EOS
+          HTML
         end
 
         it 'transforms ```notes into <div>NOTES_OPEN</div>' do
@@ -72,13 +72,13 @@ module RevealCK
       end
 
       let :standard_result do
-        <<-EOS.strip_heredoc
+        <<-HTML.strip_heredoc
         <div>DIVIDER</div>
 
         First
 
         <div>DIVIDER</div>
-        EOS
+        HTML
       end
 
       context 'without vertical slides' do
@@ -89,45 +89,45 @@ module RevealCK
         end
 
         it 'is consistent when starting+ending separators are used' do
-          input = <<-EOS.strip_heredoc
+          input = <<-SLIDES.strip_heredoc
           ---
           First
           ---
-          EOS
+          SLIDES
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         it 'is consistent when only starting separators are used' do
-          input = <<-EOS.strip_heredoc
+          input = <<-SLIDES.strip_heredoc
           ---
           First
-          EOS
+          SLIDES
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         it 'is consistent when only ending separators are used' do
-          input = <<-EOS.strip_heredoc
+          input = <<-SLIDES.strip_heredoc
           First
           ---
-          EOS
+          SLIDES
           output = PreProcessor.new(input).process
           expect(output).to eq standard_result
         end
 
         let :three_slides_input do
-          <<-EOS.strip_heredoc
+          <<-SLIDES.strip_heredoc
           First
           ---
           Second
           ---
           Third
-          EOS
+          SLIDES
         end
 
         let :three_slides_output do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <div>DIVIDER</div>
 
           First
@@ -141,7 +141,7 @@ module RevealCK
           Third
 
           <div>DIVIDER</div>
-          EOS
+          HTML
         end
 
         it 'can handle three slides' do
@@ -153,7 +153,7 @@ module RevealCK
 
       context 'with vertical slides' do
         let :single_vertical_output do
-          <<-EOS.strip_heredoc
+          <<-HTML.strip_heredoc
           <div>VERTICAL_START</div>
 
           First
@@ -167,25 +167,25 @@ module RevealCK
           Third
 
           <div>VERTICAL_END</div>
-          EOS
+          HTML
         end
 
         context 'single vertical slide' do
           it 'handles situation with no "closing" vertical' do
-            unbalanced_vertical_markdown = <<-EOS.strip_heredoc
+            unbalanced_vertical_markdown = <<-SLIDES.strip_heredoc
             ***
             First
             ---
             Second
             ---
             Third
-            EOS
+            SLIDES
             output = PreProcessor.new(unbalanced_vertical_markdown).process
             expect(output).to eq single_vertical_output
           end
 
           it 'handles situation with a "closing" vertical' do
-            balanced_vertical_markdown = <<-EOS.strip_heredoc
+            balanced_vertical_markdown = <<-SLIDES.strip_heredoc
             ***
             First
             ---
@@ -193,7 +193,7 @@ module RevealCK
             ---
             Third
             ***
-            EOS
+            SLIDES
 
             output = PreProcessor.new(balanced_vertical_markdown).process
             expect(output).to eq single_vertical_output
@@ -202,7 +202,7 @@ module RevealCK
 
         context 'horizontal and vertical combinations' do
           it 'handles vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            vertical_surrounded_by_horizontal = <<-SLIDES.strip_heredoc
             First
             ***
             Vertical 1
@@ -212,9 +212,9 @@ module RevealCK
             Vertical 3
             ***
             Last
-            EOS
+            SLIDES
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-EOS.strip_heredoc
+            expect(output).to eq <<-HTML.strip_heredoc
             <div>DIVIDER</div>
 
             First
@@ -236,11 +236,11 @@ module RevealCK
             Last
 
             <div>DIVIDER</div>
-            EOS
+            HTML
           end
 
           it 'handles back-to-back vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            vertical_surrounded_by_horizontal = <<-SLIDES.strip_heredoc
             First
             ***
             Vertical A1
@@ -257,9 +257,9 @@ module RevealCK
             Vertical B3
             ***
             Last
-            EOS
+            SLIDES
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-EOS.strip_heredoc
+            expect(output).to eq <<-HTML.strip_heredoc
             <div>DIVIDER</div>
 
             First
@@ -296,11 +296,11 @@ module RevealCK
             Last
 
             <div>DIVIDER</div>
-            EOS
+            HTML
           end
 
           it 'handles multiple vertical slides surrounded by horizontals' do
-            vertical_surrounded_by_horizontal = <<-EOS.strip_heredoc
+            vertical_surrounded_by_horizontal = <<-SLIDES.strip_heredoc
             First
             ***
             Vertical A1
@@ -318,9 +318,9 @@ module RevealCK
             Vertical B3
             ***
             Last
-            EOS
+            SLIDES
             output = PreProcessor.new(vertical_surrounded_by_horizontal).process
-            expect(output).to eq <<-EOS.strip_heredoc
+            expect(output).to eq <<-HTML.strip_heredoc
             <div>DIVIDER</div>
 
             First
@@ -358,7 +358,7 @@ module RevealCK
             Last
 
             <div>DIVIDER</div>
-            EOS
+            HTML
           end
         end
       end

--- a/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
+++ b/spec/lib/reveal-ck/markdown/slide_markdown_template_spec.rb
@@ -14,71 +14,71 @@ module RevealCK
       end
 
       it 'does not turn _s within a single emoji into <em>s' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         :money_with_wings:
-        EOS
+        SLIDES
         expect(output).to include ':money_with_wings:'
       end
 
       it 'does not turn _s between two emojis into <em>s' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         :blue_heart: :blue_heart:
-        EOS
+        SLIDES
         expect(output).to include ':blue_heart: :blue_heart:'
       end
 
       it 'uses "---" to create "<section>"s' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         # h1 Slide
         ---
         ## h2 Slide
-        EOS
+        SLIDES
         expect(output).to include '<h1>h1 Slide</h1>'
         expect(output).to include "</section>\n<section>"
         expect(output).to include '<h2>h2 Slide</h2>'
       end
 
       it 'wraps ``` code in a <pre> and <code>' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         ```
         def adder(a, b); a + b; end
         ```
-        EOS
+        SLIDES
         expect(output).to include '<pre><code>'
         expect(output).to include '</code></pre>'
         expect(output).to include 'a + b'
       end
 
       it 'converts special characters in ``` block to entity references' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         ```
         <p>"&"</p>
         ```
-        EOS
+        SLIDES
         expect(output).to include '<pre><code>'
         expect(output).to include '</code></pre>'
         expect(output).to include '&lt;p&gt;"&amp;"&lt;/p&gt;'
       end
 
       it 'wraps ```ruby code in a <pre> and <code class="language-ruby">' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         ```ruby
         def adder(a, b); a + b; end
         ```
-        EOS
+        SLIDES
         expect(output).to include '<pre><code class="language-ruby">'
         expect(output).to include '</code></pre>'
         expect(output).to include 'a + b'
       end
 
       it 'works when there is no space surrounding the ---' do
-        output = render_markdown <<-EOS.strip_heredoc
+        output = render_markdown <<-SLIDES.strip_heredoc
         # Your headline
         * Bullet 1
         * Bullet 2
         ---
         # Next Slide
-        EOS
+        SLIDES
         expect(output).to include "</section>\n<section>"
       end
     end


### PR DESCRIPTION
# Overview

This incorporates @blimmer's change around updating rack, and it also calls out that we'll use a modern rubocop and makes changes that satisfy that modern version.

The reason rack is being updated is to avoid an annoying warning. Technically the warning is associated w/ a security vulnerability, but reveal-ck is not meant to actually be run as a legit web server so this is more cosmetic than it is strictly necessary.

## Details (No Functional Changes)

If everything's gone well, this reveal-ck should be the same as the last reveal-ck.