### PR TITLE
Enforce presence of NEW_VERSION

### DIFF
--- a/rakelib/prepare_release.rake
+++ b/rakelib/prepare_release.rake
@@ -59,6 +59,8 @@ end
 desc 'Prepare to Release'
 task :prep_release do
   new_version = ENV['NEW_VERSION']
+  raise 'Need to set env NEW_VERSION' unless new_version
+
   todays_date = Time.now.strftime('%Y-%m-%d')
   update_version_rb(new_version)
   update_gemspec(todays_date)


### PR DESCRIPTION
# Overview

When you want to build a new release, you type:

    rake prep_release NEW_VERSION=3.8.1

But if you haven't done this in awhile (😃) you might forget to supply `NEW_VERSION` as an environment variable.

This change makes it so that `rake prep_release` will stop unless this is present.