### PR TITLE
[WIP] Take output dir into account when running serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,15 @@ bugs are fixed.
 
 ### Changed
 
-* Nothing
+* Modified reveal-ck to rebuild *only* when the slides file changes. Previously
+  it would build if anything underneath the current directory changed that
+  wasn't in `slides/`. Fixes #98. Thanks to @agate-pris for pointing this out.
 
 ### Fixed
 
-* Nothing.
+* Make it so that reveal-ck takes the specified or implied output directory
+  into account when running `reveal-ck serve`. Fixes #99. Thanks to @agate-pris
+  or testing!
 
 ## 3.9.0 / 2018-11-30
 

--- a/files/reveal-ck/templates/reload_Guardfile/Guardfile.erb
+++ b/files/reveal-ck/templates/reload_Guardfile/Guardfile.erb
@@ -1,5 +1,5 @@
 notification :off
 
 guard 'livereload' do
-  watch(%r{^slides/index.html$})
+  watch(%r{^<%= output_dir %>/index.html$})
 end

--- a/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
+++ b/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
@@ -6,14 +6,14 @@ module RevealCK
     # rebuilding slides.
     class ListenToRebuildSlides
       attr_reader :ui, :rebuild_method
-      def initialize(ui, output_dir, &block)
+      def initialize(ui, slides_file, &block)
         @ui = ui
-        @output_dir = output_dir
+        @slides_file = slides_file
         @rebuild_method = block
       end
 
       def run
-        ::Listen.to('.', ignore: ignored_files_regex) do |mod, add, del|
+        ::Listen.to('.', only: slides_file_regex) do |mod, add, del|
           message_and_rebuild(mod, add, del)
         end.start
       end
@@ -27,8 +27,8 @@ module RevealCK
         ui.message("#{message}: #{file_names}", :rebuild)
       end
 
-      def ignored_files_regex
-        %r{^#{@output_dir}/.+$}
+      def slides_file_regex
+        /^#{@slides_file}$/
       end
 
       def message_and_rebuild(mod, add, del)

--- a/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
+++ b/lib/reveal-ck/commands/listen_to_rebuild_slides.rb
@@ -6,8 +6,9 @@ module RevealCK
     # rebuilding slides.
     class ListenToRebuildSlides
       attr_reader :ui, :rebuild_method
-      def initialize(ui, &block)
+      def initialize(ui, output_dir, &block)
         @ui = ui
+        @output_dir = output_dir
         @rebuild_method = block
       end
 
@@ -27,7 +28,7 @@ module RevealCK
       end
 
       def ignored_files_regex
-        %r{^slides/.+$}
+        %r{^#{@output_dir}/.+$}
       end
 
       def message_and_rebuild(mod, add, del)

--- a/lib/reveal-ck/commands/listen_to_reload_browser.rb
+++ b/lib/reveal-ck/commands/listen_to_reload_browser.rb
@@ -5,8 +5,9 @@ module RevealCK
     class ListenToReloadBrowser
       attr_reader :prefix
 
-      def initialize(ui)
+      def initialize(ui, output_dir)
         @prefix = ui.prefix_for(:reload)
+        @output_dir = output_dir
       end
 
       def run
@@ -17,12 +18,23 @@ module RevealCK
 
       private
 
+      def guardfile_contents
+        guardfile_erb =
+          RevealCK.template_path('reload_Guardfile',
+                                 'Guardfile.erb')
+        template = Tilt.new(guardfile_erb)
+        locals = {
+          output_dir: @output_dir
+        }
+        template.render(self, locals)
+      end
+
       def setup_and_run_guard
         require 'guard/cli'
         Guard::UI.options[:template] = "#{prefix} :message"
-        guardfile = RevealCK.path('files/reveal-ck/Guardfile')
+        contents = guardfile_contents
         Thread.new do
-          Guard.start(guardfile: guardfile, no_interactions: true)
+          Guard.start(guardfile_contents: contents, no_interactions: true)
         end
       end
     end

--- a/lib/reveal-ck/commands/serve.rb
+++ b/lib/reveal-ck/commands/serve.rb
@@ -41,12 +41,12 @@ module RevealCK
 
       def listen_to_reload
         ui.message('Getting Ready to Reload Browsers.')
-        ListenToReloadBrowser.new(ui).run
+        ListenToReloadBrowser.new(ui, output_dir).run
       end
 
       def listen_to_rebuild
         ui.message('Getting Ready to Rebuild Slides.')
-        ListenToRebuildSlides.new(ui) do
+        ListenToRebuildSlides.new(ui, output_dir) do
           rebuild_slides
         end.run
       end

--- a/lib/reveal-ck/commands/serve.rb
+++ b/lib/reveal-ck/commands/serve.rb
@@ -46,7 +46,7 @@ module RevealCK
 
       def listen_to_rebuild
         ui.message('Getting Ready to Rebuild Slides.')
-        ListenToRebuildSlides.new(ui, output_dir) do
+        ListenToRebuildSlides.new(ui, slides_file) do
           rebuild_slides
         end.run
       end

--- a/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
+++ b/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
@@ -23,7 +23,8 @@ module RevealCK
           expect(listener)
             .to(receive(:start))
 
-          ListenToRebuildSlides.new(double('ui')).run
+          output_dir = 'slides'
+          ListenToRebuildSlides.new(double('ui'), output_dir).run
         end
       end
     end

--- a/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
+++ b/spec/lib/reveal-ck/commands/listen_to_rebuild_slides_spec.rb
@@ -9,22 +9,22 @@ module RevealCK
           '.'
         end
 
-        let :generated_slides do
-          %r{^slides/.+$}
+        let :slides_file_regex do
+          /^slides.md$/
         end
 
         it 'sets up ::Listen to run when things change' do
           listener = double
           expect(::Listen)
             .to(receive(:to))
-            .with(current_directory, ignore: generated_slides)
+            .with(current_directory, only: slides_file_regex)
             .once
             .and_return(listener)
           expect(listener)
             .to(receive(:start))
 
-          output_dir = 'slides'
-          ListenToRebuildSlides.new(double('ui'), output_dir).run
+          slides_file = 'slides.md'
+          ListenToRebuildSlides.new(double('ui'), slides_file).run
         end
       end
     end

--- a/spec/lib/reveal-ck/commands/listen_to_reload_browser_spec.rb
+++ b/spec/lib/reveal-ck/commands/listen_to_reload_browser_spec.rb
@@ -12,11 +12,19 @@ module RevealCK
             .to(receive(:prefix_for))
             .and_return('[prefix]')
 
+          output_dir = 'output_dir'
+
+          guardfile_watches_index_html_in_output_dir =
+            %r{watch\(\%r\{\^#{output_dir}\/index.html\$\}\)}
+
+          start_args = {
+            guardfile_contents: guardfile_watches_index_html_in_output_dir,
+            no_interactions: true
+          }
           expect(::Guard)
-            .to(receive(:start))
+            .to(receive(:start).with(start_args))
             .once
 
-          output_dir = 'slides'
           listen_to_reload_browser =
             ListenToReloadBrowser.new(serve_ui, output_dir)
           thread = listen_to_reload_browser.run

--- a/spec/lib/reveal-ck/commands/listen_to_reload_browser_spec.rb
+++ b/spec/lib/reveal-ck/commands/listen_to_reload_browser_spec.rb
@@ -16,7 +16,9 @@ module RevealCK
             .to(receive(:start))
             .once
 
-          listen_to_reload_browser = ListenToReloadBrowser.new(serve_ui)
+          output_dir = 'slides'
+          listen_to_reload_browser =
+            ListenToReloadBrowser.new(serve_ui, output_dir)
           thread = listen_to_reload_browser.run
           thread.join
 


### PR DESCRIPTION
# Overview

This change is being suggested to address #98 and #99.

Previously, when running `reveal-ck serve`, the software always assumed the output directory (where slides were being created) was `slides/`.

## Details

This change now takes the implied output directory into account.

This is a work in progress. If it's not too much trouble, @agate-pris, please see if this change helps your situation.

I'm a bit pressed for time right now, but I'll take a closer look when I can. I still need to:

* [x] Do some more testing
* [x] Think through the rebuilding approach-- it still rebuilds if *anything* changes underneath the present directory so long as the change isn't in the output directory. This could be especially troublesome if you have multiply-nested directories. Perhaps I should only rebuild if the slides file changes-- that makes the most sense to me now.
* [x] Write a few specs to capture the explicit and implicit cases (of `slides/` and `output_dir/`)