### PR TITLE
Fix emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ bugs are fixed.
 
 ### Fixed
 
-* Nothing.
+* Update asset_root to sync with new Github URLs for emoji. Thanks
+  @justin-vanwinkle! See See https://github.com/jedcn/reveal-ck/pull/102 for
+  details.
 
 ## 3.9.1 / 2018-12-25
 

--- a/features/emoji.feature
+++ b/features/emoji.feature
@@ -31,11 +31,11 @@ Feature: Using Emoji in your Slides
     And the file "slides/slides.html" should have html matching the xpath:
     | //section/p/img[@class="emoji"]                                                           | an img with class emoji       |
     | //section/p/img[@alt=":heart:"]                                                           | an img with alt=":heart"      |
-    | //section/p/img[@src="https://assets-cdn.github.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
+    | //section/p/img[@src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
     And the file "slides/index.html" should have html matching the xpath:
     | //section/p/img[@class="emoji"]                                                           | an img with class emoji       |
     | //section/p/img[@alt=":heart:"]                                                           | an img with alt=":heart"      |
-    | //section/p/img[@src="https://assets-cdn.github.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
+    | //section/p/img[@src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
 
   Scenario: Including Emoji in a markdown slides file
     Given a file named "slides.md" with:
@@ -49,11 +49,11 @@ Feature: Using Emoji in your Slides
     And the file "slides/slides.html" should have html matching the xpath:
     | //section/p/img[@class="emoji"]                                                           | an img with class emoji       |
     | //section/p/img[@alt=":heart:"]                                                           | an img with alt=":heart"      |
-    | //section/p/img[@src="https://assets-cdn.github.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
+    | //section/p/img[@src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
     And the file "slides/index.html" should have html matching the xpath:
     | //section/p/img[@class="emoji"]                                                           | an img with class emoji       |
     | //section/p/img[@alt=":heart:"]                                                           | an img with alt=":heart"      |
-    | //section/p/img[@src="https://assets-cdn.github.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
+    | //section/p/img[@src="https://github.githubassets.com/images/icons/emoji/unicode/2764.png"] | an img with src on github cdn |
     | //link[@rel="stylesheet"][@href="css/reveal-ck.css"]                                      | the default reveal-ck.css     |
     And a file named "slides/css/reveal-ck.css" should exist
 

--- a/lib/reveal-ck/config.rb
+++ b/lib/reveal-ck/config.rb
@@ -55,7 +55,7 @@ module RevealCK
         'filters' => ['HTML::Pipeline::RevealCKEmojiFilter',
                       'HTML::Pipeline::MentionFilter',
                       'HTML::Pipeline::AutolinkFilter'],
-        'asset_root' => 'https://assets-cdn.github.com/images/icons/',
+        'asset_root' => 'https://github.githubassets.com/images/icons/',
         'base_url' => 'https://github.com',
         'requires' => []
       }

--- a/spec/lib/reveal-ck/config_spec.rb
+++ b/spec/lib/reveal-ck/config_spec.rb
@@ -54,7 +54,7 @@ module RevealCK
 
       it 'supplies a default asset_root' do
         expect(config.asset_root)
-          .to eq 'https://assets-cdn.github.com/images/icons/'
+          .to eq 'https://github.githubassets.com/images/icons/'
       end
 
       it 'supplies a default head_prefix' do


### PR DESCRIPTION
# Overview

reveal-ck relies on github's hosting to reference emojis within slides.

Recently, github must have stopped supporting the paths they used to host emojis on-- they've switched to a new location.

That's just fine-- and I'm surprised it hasn't changed over the past four years-- so this PR supports the new URLs.

# Details

This is a fix for #101.

Thank you very much @justin-vanwinkle for reporting.