### PR TITLE
Fix a path in a link in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,4 +62,4 @@ a great way to start off.
 
 If you'd like to track something down yourself, you can find
 instructions for getting started with local development in
-[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+[docs/DEVELOPMENT.md](../docs/DEVELOPMENT.md).


### PR DESCRIPTION
# Overview

This PR updates a relative Markdown link in the CONTRIBUTING document. (Good document, by the way!) The link had broken.


## Details

  - the file had moved and a relative link broke
