### PR TITLE
Loosen `rack` version requirement.

### DIFF
--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'html-pipeline', '2.4.2'
   s.add_dependency 'kramdown', '1.13.1'
   s.add_dependency 'listen', '3.1.5'
-  s.add_dependency 'rack', '2.0.6'
+  s.add_dependency 'rack', '~> 2.0.8'
   s.add_dependency 'rack-livereload', '0.3.16'
   s.add_dependency 'rake', '12.0.0'
   s.add_dependency 'rinku', '2.0.2'


### PR DESCRIPTION
# Overview

This PR loosens the gemspec version requirements, allowing end-users to resolve this CVE https://github.com/advisories/GHSA-hrqr-hxpp-chr3 .

## Details

~> 2.0.8 means ">= 2.0.8" but "< 2.1", which felt safe here since this is the same major/minor version specified before. The "squiggly arrow" allow users to upgrade bugfix releases more easily in the future.