### PR TITLE
Upgrade HAML to latest version

### DIFF
--- a/reveal-ck.gemspec
+++ b/reveal-ck.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'gli', '2.14.0'
   s.add_dependency 'guard', '2.14.0'
   s.add_dependency 'guard-livereload', '2.5.2'
-  s.add_dependency 'haml', '4.0.7'
+  s.add_dependency 'haml', '~> 5.1.2'
   s.add_dependency 'html-pipeline', '2.4.2'
   s.add_dependency 'kramdown', '1.13.1'
   s.add_dependency 'listen', '3.1.5'


### PR DESCRIPTION
# Overview

This PR allows end-users to resolve this CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-1002201

## Details

Since this is a major version upgrade, we should definitely call this out in the changelog and maybe even do a major version release of reveal-ck to encourage folks to read the changelog.

Here are the relevant breaking changes in HAML 4 -> 5: https://github.com/haml/haml/blob/master/CHANGELOG.md#500
